### PR TITLE
feat: add history feature with IndexedDB persistence (Issue #16)

### DIFF
--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { useRef, useEffect, useState, useCallback } from 'react';
+import type { MagicCircleHistory } from '@/lib/types';
+import type { MagicCirclePattern } from '@/lib/patterns';
+import type { DrawEvent } from '@/lib/types';
+
+interface HistoryDetailProps {
+  history: MagicCircleHistory | null;
+  onClose: () => void;
+  onReEdit: (data: Pick<MagicCircleHistory, 'data'>) => void;
+}
+
+const CANVAS_SIZE = 350;
+
+function createReplayDrawLogs(strokes: MagicCircleHistory['data']['drawLogs']): DrawEvent[][] {
+  return strokes.map((stroke) => {
+    if (stroke.length === 0) return [];
+    const t0 = stroke[0].t;
+    return stroke.map((e) => ({ ...e, t: e.t - t0 }));
+  });
+}
+
+export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDetailProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const replayAnimRef = useRef<number | null>(null);
+  const [isReplaying, setIsReplaying] = useState(false);
+  const [debugMsg, setDebugMsg] = useState('');
+
+  const drawTemplate = useCallback((pattern: Pick<MagicCirclePattern, 'circles' | 'edges' | 'vertices' | 'name'>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+    // Draw circles
+    for (const circle of pattern.circles) {
+      ctx.strokeStyle = 'rgba(100, 100, 150, 0.3)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(circle.cx * CANVAS_SIZE, circle.cy * CANVAS_SIZE, circle.radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    // Draw edges
+    ctx.strokeStyle = 'rgba(100, 100, 150, 0.5)';
+    ctx.lineWidth = 3;
+    ctx.setLineDash([5, 5]);
+    for (const edge of pattern.edges) {
+      const a = pattern.vertices[edge.from];
+      const b = pattern.vertices[edge.to];
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
+  }, []);
+
+  useEffect(() => {
+    if (!history || !canvasRef.current) return;
+    drawTemplate(history.data.pattern);
+  }, [history, drawTemplate]);
+
+  // Cleanup replay animation on unmount
+  useEffect(() => {
+    return () => {
+      if (replayAnimRef.current !== null) {
+        cancelAnimationFrame(replayAnimRef.current);
+        replayAnimRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleReplay = useCallback(() => {
+    if (!history || isReplaying) return;
+    setIsReplaying(true);
+
+    const drawLogs = history.data.drawLogs;
+    const canvas = canvasRef.current;
+    if (!canvas) { setIsReplaying(false); return; }
+    const ctx = canvas.getContext('2d');
+    if (!ctx) { setIsReplaying(false); return; }
+
+    const normalizedLogs = createReplayDrawLogs(drawLogs);
+    const STROKE_INTERVAL_MS = 500;
+    const allEvents: DrawEvent[] = [];
+    let timeOffset = 0;
+    for (const stroke of normalizedLogs) {
+      if (stroke.length === 0) continue;
+      for (const ev of stroke) {
+        allEvents.push({ x: ev.x, y: ev.y, t: ev.t + timeOffset, type: ev.type });
+      }
+      timeOffset = allEvents[allEvents.length - 1].t + STROKE_INTERVAL_MS;
+    }
+
+    if (allEvents.length === 0) { setIsReplaying(false); return; }
+    const totalDuration = allEvents[allEvents.length - 1].t;
+
+    const startTime = performance.now();
+
+    const animate = (now: number) => {
+      const elapsed = now - startTime;
+      drawTemplate(history.data.pattern);
+
+      const pts: { x: number; y: number }[] = [];
+      for (const ev of allEvents) {
+        if (ev.t <= elapsed) {
+          pts.push({ x: ev.x, y: ev.y });
+        }
+      }
+
+      if (pts.length > 1) {
+        ctx.shadowBlur = 15;
+        ctx.shadowColor = '#00e5ff';
+        ctx.strokeStyle = '#00e5ff';
+        ctx.lineWidth = 4;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        ctx.beginPath();
+        ctx.moveTo(pts[0].x, pts[0].y);
+        for (let i = 1; i < pts.length; i++) {
+          ctx.lineTo(pts[i].x, pts[i].y);
+        }
+        ctx.stroke();
+        ctx.shadowBlur = 0;
+
+        // Leading glow
+        const last = pts[pts.length - 1];
+        ctx.shadowBlur = 20;
+        ctx.shadowColor = '#00e5ff';
+        ctx.fillStyle = '#ffffff';
+        ctx.beginPath();
+        ctx.arc(last.x, last.y, 6, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.shadowBlur = 8;
+        ctx.fillStyle = '#00e5ff';
+        ctx.beginPath();
+        ctx.arc(last.x, last.y, 10, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.shadowBlur = 0;
+      }
+
+      if (elapsed >= totalDuration) {
+        drawTemplate(history.data.pattern);
+        if (pts.length > 1) {
+          ctx.shadowBlur = 15;
+          ctx.shadowColor = '#00e5ff';
+          ctx.strokeStyle = '#00e5ff';
+          ctx.lineWidth = 4;
+          ctx.lineCap = 'round';
+          ctx.lineJoin = 'round';
+          ctx.beginPath();
+          ctx.moveTo(pts[0].x, pts[0].y);
+          for (let i = 1; i < pts.length; i++) {
+            ctx.lineTo(pts[i].x, pts[i].y);
+          }
+          ctx.stroke();
+          ctx.shadowBlur = 0;
+        }
+        setDebugMsg('🔄 リプレイ完了！');
+        replayAnimRef.current = null;
+        setIsReplaying(false);
+        return;
+      }
+
+      replayAnimRef.current = requestAnimationFrame(animate);
+    };
+
+    replayAnimRef.current = requestAnimationFrame(animate);
+    setDebugMsg('🔄 リプレイ再生中...');
+  }, [history, isReplaying, drawTemplate]);
+
+  const handleCancelReplay = useCallback(() => {
+    if (replayAnimRef.current !== null) {
+      cancelAnimationFrame(replayAnimRef.current);
+      replayAnimRef.current = null;
+    }
+    setIsReplaying(false);
+    setDebugMsg('');
+    if (history) drawTemplate(history.data.pattern);
+  }, [history, drawTemplate]);
+
+  if (!history) return null;
+
+  const getRankColor = (rank: string): string => {
+    switch (rank) {
+      case 'S': return '#ffd700';
+      case 'A': return '#00e5ff';
+      case 'B': return '#76ff03';
+      default: return '#ff4081';
+    }
+  };
+
+  const formatDate = (ts: number): string => {
+    const d = new Date(ts);
+    return d.toLocaleString('ja-JP');
+  };
+
+  const drawAllStroke = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    drawTemplate(history.data.pattern);
+
+    const allPoints: { x: number; y: number }[] = [];
+    for (const stroke of history.data.drawLogs) {
+      for (const ev of stroke) {
+        allPoints.push({ x: ev.x, y: ev.y });
+      }
+    }
+    if (allPoints.length > 1) {
+      ctx.shadowBlur = 15;
+      ctx.shadowColor = '#00e5ff';
+      ctx.strokeStyle = '#00e5ff';
+      ctx.lineWidth = 4;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.beginPath();
+      ctx.moveTo(allPoints[0].x, allPoints[0].y);
+      for (let i = 1; i < allPoints.length; i++) {
+        ctx.lineTo(allPoints[i].x, allPoints[i].y);
+      }
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+    }
+    setDebugMsg('');
+  }, [history, drawTemplate]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 z-40 bg-black/60" onClick={onClose} />
+      {/* Modal */}
+      <div
+        className="fixed inset-4 z-50 flex flex-col overflow-auto rounded-2xl"
+        style={{ background: '#0d0d1a', border: '1px solid rgba(0,229,255,0.3)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3">
+          <h2 className="text-lg font-bold" style={{ color: '#00e5ff' }}>📜 履歴詳細</h2>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-800 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 p-4 sm:flex-row">
+          {/* Canvas Area */}
+          <div className="flex w-full flex-col items-center sm:w-1/2">
+            <canvas
+              ref={canvasRef}
+              width={CANVAS_SIZE}
+              height={CANVAS_SIZE}
+              className="w-full max-w-[350px] rounded-lg border-2 border-gray-700"
+              style={{ background: '#0a0a14', display: 'block' }}
+            />
+
+            {/* Debug / Status */}
+            {debugMsg && (
+              <div className="mt-2 rounded-lg bg-black/80 px-3 py-1 text-center text-xs font-mono text-green-400">
+                {debugMsg}
+              </div>
+            )}
+
+            {/* Action Buttons */}
+            <div className="mt-3 flex gap-2 flex-wrap justify-center">
+              <button
+                onClick={handleReplay}
+                disabled={isReplaying}
+                className="cursor-pointer rounded-md px-4 py-2 text-sm font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+                style={{ background: 'linear-gradient(135deg, #ffd700, #ff9100)' }}
+              >
+                {isReplaying ? '再生中...' : '🔄 リプレイ'}
+              </button>
+              {isReplaying && (
+                <button
+                  onClick={handleCancelReplay}
+                  className="cursor-pointer rounded-md border-2 border-gray-600 px-4 py-2 text-sm font-bold transition-colors hover:bg-gray-800"
+                >
+                  停止
+                </button>
+              )}
+              <button
+                onClick={drawAllStroke}
+                className="cursor-pointer rounded-md border-2 border-gray-600 px-4 py-2 text-sm font-bold transition-colors hover:bg-gray-800"
+                style={{ borderColor: 'rgba(0,229,255,0.3)', color: '#00e5ff' }}
+              >
+                👁️ 最終描画
+              </button>
+            </div>
+          </div>
+
+          {/* Info Area */}
+          <div className="w-full sm:w-1/2">
+            {/* Result Summary */}
+            <div
+              className="mb-4 rounded-lg p-4 text-center"
+              style={{ background: 'rgba(124, 77, 255, 0.1)', border: '1px solid rgba(124, 77, 255, 0.3)' }}
+            >
+              <div className="text-5xl font-bold" style={{ color: getRankColor(history.rank) }}>
+                {history.rank}
+              </div>
+              <div className="mt-1 text-xl" style={{ color: '#7c4dff' }}>
+                {history.score}点
+              </div>
+              <div className="mt-1 text-sm text-gray-400">
+                難易度: {history.difficulty} (×{history.difficultyMultiplier})
+              </div>
+              <div className="mt-1 text-sm text-gray-400">
+                威力: {history.damageMultiplier}
+              </div>
+            </div>
+
+            {/* Pattern Info */}
+            <div className="mb-4">
+              <div className="text-sm text-gray-500">魔法陣</div>
+              <div className="text-base font-bold" style={{ color: '#00e5ff' }}>
+                {history.data.pattern.name}
+              </div>
+              <div className="text-xs text-gray-600">
+                {history.data.drawLogs.length}ストローク
+              </div>
+            </div>
+
+            {/* Timestamp */}
+            <div className="mb-4">
+              <div className="text-sm text-gray-500">作成日時</div>
+              <div className="text-sm" style={{ color: '#9c9caf' }}>
+                {formatDate(history.createdAt)}
+              </div>
+            </div>
+
+            {/* Re-edit Button */}
+            <button
+              onClick={() => onReEdit({ data: history.data })}
+              className="cursor-pointer rounded-lg px-6 py-3 text-sm font-bold text-black transition-transform hover:scale-105 active:scale-95 w-full"
+              style={{ background: 'linear-gradient(135deg, #76ff03, #00e5ff)' }}
+            >
+              ✏️ この履歴で再編集
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import type { MagicCircleHistory } from '@/lib/types';
+import { getAllHistories, deleteHistory } from '@/lib/historyDB';
+
+interface HistoryPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (history: MagicCircleHistory) => void;
+}
+
+export default function HistoryPanel({ isOpen, onClose, onSelect }: HistoryPanelProps) {
+  const [histories, setHistories] = useState<MagicCircleHistory[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadHistories = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await getAllHistories();
+      setHistories(data);
+    } catch (e) {
+      console.error('Failed to load histories:', e);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) loadHistories();
+  }, [isOpen, loadHistories]);
+
+  const handleDelete = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    try {
+      await deleteHistory(id);
+      setHistories((prev) => prev.filter((h) => h.id !== id));
+    } catch (e) {
+      console.error('Failed to delete history:', e);
+    }
+  };
+
+  const formatTime = (timestamp: number): string => {
+    const d = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffSec = Math.floor(diffMs / 1000);
+    const diffMin = Math.floor(diffSec / 60);
+    const diffHour = Math.floor(diffMin / 60);
+    const diffDay = Math.floor(diffHour / 24);
+
+    if (diffSec < 60) return 'たった今';
+    if (diffMin < 60) return `${diffMin}分前`;
+    if (diffHour < 24) return `${diffHour}時間前`;
+    if (diffDay < 7) return `${diffDay}日前`;
+    return d.toLocaleDateString('ja-JP');
+  };
+
+  const getRankColor = (rank: string): string => {
+    switch (rank) {
+      case 'S': return '#ffd700';
+      case 'A': return '#00e5ff';
+      case 'B': return '#76ff03';
+      default: return '#ff4081';
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/50"
+        onClick={onClose}
+      />
+      {/* Panel */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-50 flex max-h-[70vh] flex-col rounded-t-2xl"
+        style={{ background: '#0d0d1a', border: '1px solid rgba(0,229,255,0.2)', borderBottom: 'none' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3">
+          <h2 className="text-lg font-bold" style={{ color: '#00e5ff' }}>📜 作成履歴</h2>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-800 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8 text-gray-400">読み込み中...</div>
+          )}
+          {!isLoading && histories.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+              <span className="text-3xl">📭</span>
+              <p className="mt-2 text-sm">まだ履歴がありません</p>
+            </div>
+          )}
+          {!isLoading && histories.length > 0 && (
+            <div className="grid grid-cols-2 gap-3 p-3 sm:grid-cols-3 md:grid-cols-4">
+              {histories.map((h) => (
+                <div
+                  key={h.id}
+                  onClick={() => onSelect(h)}
+                  className="group relative cursor-pointer overflow-hidden rounded-lg border border-gray-700 transition-all hover:border-cyan-500 active:scale-95"
+                  style={{ background: '#0a0a14' }}
+                >
+                  {/* Thumbnail */}
+                  <div className="relative aspect-square w-full overflow-hidden" style={{ background: '#0a0a14' }}>
+                    {h.thumbnail ? (
+                      <img
+                        src={h.thumbnail}
+                        alt={h.data.pattern.name}
+                        className="h-full w-full object-contain"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-2xl text-gray-600">
+                        🔮
+                      </div>
+                    )}
+                    {/* Overlay rank badge */}
+                    <div
+                      className="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold"
+                      style={{
+                        background: `${getRankColor(h.rank)}22`,
+                        color: getRankColor(h.rank),
+                        border: `1px solid ${getRankColor(h.rank)}`,
+                      }}
+                    >
+                      {h.rank}
+                    </div>
+                    {/* Delete button */}
+                    <button
+                      onClick={(e) => handleDelete(e, h.id)}
+                      className="absolute bottom-1 right-1 rounded-full bg-black/70 p-1 text-xs text-gray-400 opacity-0 transition-opacity group-hover:opacity-100"
+                      title="削除"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+
+                  {/* Info */}
+                  <div className="p-2 text-center">
+                    <div className="truncate text-xs font-bold" style={{ color: '#7c4dff' }}>
+                      {h.data.pattern.name}
+                    </div>
+                    <div className="text-xs text-gray-500">{formatTime(h.createdAt)}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -1,20 +1,25 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import type { ScoringResult } from '@/lib/scoring';
 import type { Difficulty } from '@/lib/patterns';
 import { useMagicCircle } from '@/hooks/useMagicCircle';
+import type { MagicCircleData, MagicCircleHistory } from '@/lib/types';
 import HelpModal from './HelpModal';
+import HistoryPanel from './HistoryPanel';
+import HistoryDetail from './HistoryDetail';
 import TutorialOverlay from './TutorialOverlay';
 
 export default function MagicCircleCanvas({
   onScore,
   onReset,
   initialDifficulty,
+  onLoadDataRef,
 }: {
   onScore: (result: ScoringResult) => void;
   onReset: () => void;
   initialDifficulty: Difficulty;
+  onLoadDataRef?: (loadFn: (data: MagicCircleData) => void) => void;
 }) {
   const {
     canvasRef, canvasSize, isDrawing, userPath,
@@ -28,9 +33,35 @@ export default function MagicCircleCanvas({
 
   const [showHelp, setShowHelp] = useState(false);
   const [showTutorial, setShowTutorial] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  const [selectedHistory, setSelectedHistory] = useState<MagicCircleHistory | null>(null);
 
   // Sync external difficulty prop
   useEffect(() => { changeDifficulty(initialDifficulty); }, [initialDifficulty, changeDifficulty]);
+
+  // Expose load function to parent via ref callback
+  const passLoadData = useCallback(() => {
+    if (onLoadDataRef) onLoadDataRef(handleLoadData);
+  }, [onLoadDataRef, handleLoadData]);
+
+  useEffect(() => {
+    passLoadData();
+  }, [passLoadData]);
+
+  const handleHistorySelect = (history: MagicCircleHistory) => {
+    setSelectedHistory(history);
+    setShowHistory(false);
+  };
+
+  const handleCloseDetail = () => {
+    setSelectedHistory(null);
+  };
+
+  const handleReEdit = ({ data }: { data: MagicCircleData }) => {
+    handleReset();
+    handleLoadData(data);
+    setSelectedHistory(null);
+  };
 
   const guideText = patternName
     ? `赤い点から「${patternName}」をなぞってください`
@@ -50,6 +81,16 @@ export default function MagicCircleCanvas({
         aria-label="ヘルプ"
       >
         ?
+      </button>
+
+      {/* 履歴ボタン */}
+      <button
+        onClick={() => setShowHistory(true)}
+        className="absolute left-4 top-4 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 text-lg font-bold"
+        style={{ borderColor: 'rgba(124,77,255,0.5)', color: '#7c4dff', background: 'rgba(10,10,20,0.8)' }}
+        aria-label="履歴"
+      >
+        📜
       </button>
 
       {/* パターン名とカウンター */}
@@ -195,6 +236,20 @@ export default function MagicCircleCanvas({
           次の魔法陣 →
         </button>
       </div>
+
+      {/* History Panel */}
+      <HistoryPanel
+        isOpen={showHistory}
+        onClose={() => setShowHistory(false)}
+        onSelect={handleHistorySelect}
+      />
+
+      {/* History Detail Modal */}
+      <HistoryDetail
+        history={selectedHistory}
+        onClose={handleCloseDetail}
+        onReEdit={handleReEdit}
+      />
     </div>
   );
 }

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -13,7 +13,8 @@ import {
   DIFFICULTY_TOLERANCE,
   DIFFICULTY_LABELS,
 } from '@/lib/patterns';
-import type { DrawEvent, DrawStroke, MagicCircleData } from '@/lib/types';
+import type { DrawEvent, DrawStroke, MagicCircleData, MagicCircleHistory } from '@/lib/types';
+import { addHistory } from '@/lib/historyDB';
 
 const CANVAS_SIZE = 350;
 
@@ -256,7 +257,45 @@ export function useMagicCircle(
       navigator.vibrate(100);
     }
     onScore(result);
-  }, [userPath, currentPattern, difficulty, onScore]);
+
+    // ─── 作成後自動保存 (履歴に保存) ───
+    const data: MagicCircleData = {
+      seed: Math.floor(Math.random() * 1e9),
+      pattern: {
+        name: currentPattern.name,
+        vertices: currentPattern.vertices,
+        edges: currentPattern.edges,
+        circles: currentPattern.circles,
+      },
+      drawLogs: drawLogs.map((stroke) => [...stroke]),
+      timestamp: Date.now(),
+    };
+
+    // Generate thumbnail from canvas
+    let thumbnail: string | undefined;
+    try {
+      const canvas = canvasRef.current;
+      if (canvas) {
+        thumbnail = canvas.toDataURL('image/png');
+      }
+    } catch {
+      // Thumbnail generation failed, continue without it
+    }
+
+    const historyItem: MagicCircleHistory = {
+      id: `history_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      data,
+      score: result.score,
+      rank: result.rank,
+      difficulty: DIFFICULTY_LABELS[difficulty],
+      difficultyMultiplier: result.difficultyMultiplier,
+      damageMultiplier: result.damageMultiplier,
+      thumbnail,
+      createdAt: Date.now(),
+    };
+
+    addHistory(historyItem).catch((e) => console.error('Failed to save history:', e));
+  }, [userPath, currentPattern, difficulty, onScore, drawLogs, canvasRef]);
 
   const handleReset = useCallback(() => {
     setIsDrawing(false);

--- a/src/lib/historyDB.ts
+++ b/src/lib/historyDB.ts
@@ -1,0 +1,79 @@
+import type { MagicCircleHistory } from '@/lib/types';
+
+const DB_NAME = 'ArcaneTracerHistory';
+const DB_VERSION = 1;
+const STORE_NAME = 'history';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('createdAt', 'createdAt', { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** 履歴をすべて取得 (新しい順) */
+export async function getAllHistories(): Promise<MagicCircleHistory[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const index = store.index('createdAt');
+    const request = index.openCursor(undefined, 'prev');
+    const results: MagicCircleHistory[] = [];
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (cursor) {
+        results.push(cursor.value as MagicCircleHistory);
+        cursor.continue();
+      } else {
+        resolve(results);
+      }
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** 履歴を1件追加 */
+export async function addHistory(history: MagicCircleHistory): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.add(history);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    tx.oncomplete = () => {};
+  });
+}
+
+/** 履歴を1件削除 */
+export async function deleteHistory(id: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.delete(id);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** 履歴を1件取得 */
+export async function getHistoryById(id: string): Promise<MagicCircleHistory | undefined> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.get(id);
+    request.onsuccess = () => resolve(request.result as MagicCircleHistory | undefined);
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,3 +24,16 @@ export interface MagicCircleData {
   drawLogs: DrawStroke[];
   timestamp: number;
 }
+
+/** 魔法陣履歴データ (保存・表示用) */
+export interface MagicCircleHistory {
+  id: string;
+  data: MagicCircleData;
+  score: number;
+  rank: string;
+  difficulty: string;
+  difficultyMultiplier: number;
+  damageMultiplier: string;
+  thumbnail?: string; // DataURL of canvas snapshot
+  createdAt: number;
+}


### PR DESCRIPTION
## Summary

Implement Issue #16 — History Feature for Arcane Tracer 📜

### Features

- **IndexedDB persistence**: `MagicCircleHistory` records are stored in IndexedDB with full drawing data
- **History list UI**: Bottom-sheet panel showing thumbnails with timestamps and rank badges
- **History detail view**: Modal with canvas preview, animated replay, and re-edit capability
- **Auto-save after scoring**: Every evaluation automatically saves the result to history (including canvas thumbnail)
- **Delete functionality**: Each history item has a delete button (visible on hover)

### Implementation Details

| File | Description |
|---|---|
| `src/lib/types.ts` | Added `MagicCircleHistory` interface |
| `src/lib/historyDB.ts` | New — IndexedDB CRUD wrapper (`getAllHistories`, `addHistory`, `deleteHistory`, `getHistoryById`) |
| `src/components/HistoryPanel.tsx` | New — History list panel with thumbnail grid |
| `src/components/HistoryDetail.tsx` | New — Detail modal with replay/re-edit |
| `src/hooks/useMagicCircle.ts` | Auto-save logic added to `handleEvaluate` |
| `src/components/MagicCircleCanvas.tsx` | History button (📜), panel & modal integration |

### How to use

1. Complete a magic circle drawing and press 「詠唱完了！」→ auto-saved to history
2. Click the 📜 button (top-left) to open the history panel
3. Tap a history card to see details (preview, replay, score info)
4. Use 「リプレイ」 for animated replay or 「再編集」 to load the drawing data

---

*This PR was created by an AI assistant (OpenHands) on behalf of the developer.*