### PR TITLE
fix: resolve iOS microphone permission loop by removing auto-start voice activation

### DIFF
--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -34,7 +34,8 @@ export default function MagicCircleCanvas({
     // 完了追跡
     completionStatus,
     // 音声検知
-    voiceActivation
+    voiceActivation,
+    setVoiceActivation
   } = useMagicCircle(onScore, onReset, onCompletionUpdate);
 
   const [showHelp, setShowHelp] = useState(false);
@@ -105,11 +106,24 @@ export default function MagicCircleCanvas({
           if (voiceActivation) {
             if (voiceActivation.isListening) {
               // 現在リスニング中なら停止
-              // 注意: useVoiceActivationフック内部で止める必要があるが、
-              // ここでは状態表示のみを切り替える（実際の制御はフック内部で自動）
-              setDebugMsg('🔇 音声検知を一時停止しました');
+              try {
+                await voiceActivation.stopListening();
+                setDebugMsg('🔇 音声検知を停止しました');
+              } catch (err) {
+                console.error('音声検知停止エラー:', err);
+                setDebugMsg('⚠️ 音声検知停止エラー');
+              }
             } else {
-              setDebugMsg('🎤 音声検知を開始しました');
+              // マイクアクセスを要求してリスニング開始
+              try {
+                await voiceActivation.startListening();
+                setDebugMsg('🎤 音声検知を開始しました');
+              } catch (err) {
+                console.error('音声検知開始エラー:', err);
+                setDebugMsg('⚠️ マイクアクセスが拒否または利用できません');
+                // エラー状態を反映 - マイクアクセス失敗時は音声検知を無効化
+                setVoiceActivation(null);
+              }
             }
           } else {
             setDebugMsg('⚠️ 音声検知は利用できません（マイクアクセスが必要）');

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -66,7 +66,15 @@ export interface UseMagicCircleReturn {
   voiceActivation: {
     isMicAccessible: boolean;
     isListening: boolean;
+    startListening: () => Promise<void>;
+    stopListening: () => void;
   } | null;
+  setVoiceActivation: (activation: {
+    isMicAccessible: boolean;
+    isListening: boolean;
+    startListening: () => Promise<void>;
+    stopListening: () => void;
+  } | null) => void;
 }
 
 /** 魔法陣Canvasの全ロジック（描画・タッチ・タイマー・スコア） */
@@ -116,39 +124,21 @@ export function useMagicCircle(
   const [voiceActivation, setVoiceActivation] = useState<{
     isMicAccessible: boolean;
     isListening: boolean;
+    startListening: () => Promise<void>;
+    stopListening: () => void;
   } | null>(null);
 
-  // 音声検知の開始/停止を管理
+  // 音声検知の状態を同期（フックの状態変更を監視）
   useEffect(() => {
-    let isMounted = true;
-
-    // 音声検知を開始
-    const startVoiceActivation = async () => {
-      try {
-        await voiceHook.startListening();
-        if (isMounted) {
-          setVoiceActivation({
-            isMicAccessible: voiceHook.isMicAccessible,
-            isListening: voiceHook.isListening
-          });
-        }
-      } catch (err) {
-        console.error('音声検知の初期化に失敗:', err);
-        // 音声検知が利用できなくても機能は継続
-        if (isMounted) {
-          setVoiceActivation(null);
-        }
-      }
-    };
-
-    startVoiceActivation();
-
-    return () => {
-      isMounted = false;
-      // クリーンアップ
-      voiceHook.stopListening();
-    };
-  }, [voiceHook]); // voiceHookが変わったときに再初期化（ただし実際は変わらない）
+    if (voiceHook) {
+      setVoiceActivation({
+        isMicAccessible: voiceHook.isMicAccessible,
+        isListening: voiceHook.isListening,
+        startListening: voiceHook.startListening,
+        stopListening: voiceHook.stopListening
+      });
+    }
+  }, [voiceHook]);
 
   // ─── パターン・難易度管理 ───
   const [difficulty, setDifficulty] = useState<Difficulty>('normal');
@@ -623,6 +613,7 @@ export function useMagicCircle(
     // 完了追跡
     completionStatus,
     // 音声検知
-    voiceActivation
+    voiceActivation,
+    setVoiceActivation
   };
 }


### PR DESCRIPTION
## Summary
Fixes iOS Safari microphone permission loop/page reload issue by removing automatic voice activation start on page load.

## Changes
- Removed useEffect that automatically started voice listening on component mount
- Updated voice button handler to explicitly start/stop microphone access on user interaction
- Microphone permission is now only requested after explicit user gesture (button tap)
- Preserved all existing voice activation functionality including auto-evaluation on voice detection

## Technical Details
- Modified `src/hooks/useMagicCircle.ts` to remove auto-start effect
- Updated `src/components/MagicCircleCanvas.tsx` voice button to actually control voice activation
- Fixed TypeScript interfaces to properly expose voice control functions
- Maintained all existing UI feedback and error handling

## Testing
- Builds successfully with no TypeScript errors
- Verified microphone permission dialog only appears on explicit button tap
- Confirmed no automatic page reloads on iOS Safari