### PR TITLE
Move replay button to evaluation screen

### DIFF
--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -241,6 +241,14 @@ export default function MagicCircleCanvas({
                 🔄 再挑戦
               </button>
               <button
+                onClick={handleReplay}
+                disabled={drawLogs.length === 0 || isReplaying}
+                className="cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-80"
+                style={{ background: 'linear-gradient(135deg, #ffd700, #ff9100)' }}
+              >
+                {isReplaying ? '再生中...' : '🔄 リプレイ'}
+              </button>
+              <button
                 onClick={handleNext}
                 className="flex items-center px-6 py-3 rounded-lg font-medium transition-all"
                 style={{ background: 'linear-gradient(135deg, #7c4dff, #ff4081)' }}
@@ -297,14 +305,6 @@ export default function MagicCircleCanvas({
           style={{ background: 'linear-gradient(135deg, #00e5ff, #7c4dff)' }}
         >
           詠唱完了！
-        </button>
-        <button
-          onClick={handleReplay}
-          disabled={drawLogs.length === 0 || isReplaying}
-          className="cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-80"
-          style={{ background: 'linear-gradient(135deg, #ffd700, #ff9100)' }}
-        >
-          {isReplaying ? '再生中...' : '🔄 リプレイ'}
         </button>
         <button
           onClick={() => handleSaveData()}


### PR DESCRIPTION
Relocated the replay button from the regular UI area to the evaluation screen (shown when showResult is true) so users can easily replay their attempt immediately after seeing their score and results.

This change addresses issue #44: 評価画面にリプレイボタンを移動する

Changes:
- Added replay button to evaluation screen alongside "再挑戦" and "次の魔法陣 →" buttons
- Removed duplicate replay button from regular UI area
- Maintained identical functionality and styling
- Button properly disabled when no draw logs exist or during replay