### PR TITLE
Integrate pagination into magic circle title row

### DIFF
--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -27,7 +27,7 @@ export default function MagicCircleCanvas({
     canvasRef, canvasSize, isDrawing, userPath,
     timeLeft, isActive, showResult, scoreResult,
     debugMsg, setDebugMsg, startPoint, patternName, currentIndex, totalPatterns,
-    difficulty, difficultyLabel, handleEvaluate, handleReset, handleNext, changeDifficulty,
+    difficulty, difficultyLabel, handleEvaluate, handleReset, handleNext, handlePrevious, changeDifficulty,
     getRankColor, onPointerDown, onPointerMove, onPointerUp,
     // リプレイ関連
     drawLogs, savedMagicData, isReplaying, handleReplay, handleSaveData, handleLoadData,
@@ -159,15 +159,29 @@ export default function MagicCircleCanvas({
         </button>
       )}
 
-      {/* パターン名とカウンター - プレイ中は簡素化 */}
+      {/* パターン名とページネーション - プレイ中は簡素化 */}
       {!isActive && (
-        <div className="flex items-center gap-3 text-sm">
-          <span className="font-bold" style={{ color: '#7c4dff' }}>
+        <div className="flex items-center gap-2 text-sm">
+          <button
+            onClick={handlePrevious}
+            disabled={currentIndex === 0}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-gray-600 bg-gray-800/50 text-gray-400 hover:bg-gray-600/70 transition-colors disabled:opacity-50"
+          >
+            〈
+          </button>
+          <span className="flex-1 flex items-center justify-center font-bold" style={{ color: '#7c4dff' }}>
             {patternName || '準備中...'}
           </span>
           <span className="text-gray-500">
             #{currentIndex + 1} / {totalPatterns}
           </span>
+          <button
+            onClick={handleNext}
+            disabled={currentIndex >= totalPatterns - 1}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-gray-600 bg-gray-800/50 text-gray-400 hover:bg-gray-600/70 transition-colors disabled:opacity-50"
+          >
+            〉
+          </button>
         </div>
       )}
 
@@ -239,13 +253,6 @@ export default function MagicCircleCanvas({
                 style={{ background: 'linear-gradient(135deg, #ff4081, #7c4dff)' }}
               >
                 🔄 再挑戦
-              </button>
-              <button
-                onClick={handleNext}
-                className="flex items-center px-6 py-3 rounded-lg font-medium transition-all"
-                style={{ background: 'linear-gradient(135deg, #7c4dff, #ff4081)' }}
-              >
-                次の魔法陣 →
               </button>
             </div>
           </div>
@@ -319,13 +326,6 @@ export default function MagicCircleCanvas({
           className="cursor-pointer rounded-md border-2 border-gray-600 px-6 py-2 font-bold transition-colors hover:bg-gray-800"
         >
           リセット
-        </button>
-        <button
-          onClick={handleNext}
-          className="cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity hover:opacity-80"
-          style={{ background: 'linear-gradient(135deg, #7c4dff, #ff4081)' }}
-        >
-          次の魔法陣 →
         </button>
       </div>
 

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -48,6 +48,7 @@ export interface UseMagicCircleReturn {
   handleEvaluate: () => void;
   handleReset: () => void;
   handleNext: () => void;
+  handlePrevious: () => void;
   changeDifficulty: (d: Difficulty) => void;
   getRankColor: (rank: string) => string;
   onPointerDown: (e: React.PointerEvent) => void;
@@ -466,6 +467,28 @@ export function useMagicCircle(
     setIsReplaying(false);
   }, [difficulty]);
 
+  const handlePrevious = useCallback(() => {
+    // Go to previous pattern if available
+    if (currentIdx > 0) {
+      setCurrentIdx((prev) => prev - 1);
+      setIsDrawing(false);
+      setUserPath([]);
+      setIsActive(false);
+      setShowResult(false);
+      setScoreResult(null);
+      setActualTimeLeft(DIFFICULTY_TIME[difficulty]);
+      setDebugMsg(`前のパターン: ${patterns[currentIdx - 1].name}`);
+      // 描画ログもクリア
+      setDrawLogs([]);
+      drawLogRef.current = [];
+      if (replayAnimRef.current !== null) {
+        cancelAnimationFrame(replayAnimRef.current);
+        replayAnimRef.current = null;
+      }
+      setIsReplaying(false);
+    }
+  }, [currentIdx, difficulty]);
+
   const changeDifficulty = useCallback((d: Difficulty) => {
     setDifficulty(d);
   }, []);
@@ -633,7 +656,7 @@ export function useMagicCircle(
     timeLeft: actualTimeLeft, isActive, showResult, scoreResult, debugMsg, setDebugMsg,
     startPoint, patternName, currentIndex: currentIdx, totalPatterns: patterns.length,
     difficulty, difficultyLabel: DIFFICULTY_LABELS[difficulty],
-    handleEvaluate, handleReset, handleNext, changeDifficulty, getRankColor,
+    handleEvaluate, handleReset, handleNext, handlePrevious, changeDifficulty, getRankColor,
     onPointerDown, onPointerMove, onPointerUp,
     drawLogs, savedMagicData, isReplaying, handleReplay, handleSaveData, handleLoadData,
     // 完了追跡


### PR DESCRIPTION
Implements feature #48: Integrate pagination into the magic circle title row and remove the '次の魔法陣 →' buttons.

Changes:
- Modified src/hooks/useMagicCircle.ts:
  * Added handlePrevious function to navigate to previous pattern
  * Added handlePrevious to the UseMagicCircleReturn interface and return statement
- Modified src/components/MagicCircleCanvas.tsx:
  * Added handlePrevious to destructuring
  * Replaced simple title/counter row with pagination controls:
    - Previous button (〈) on left
    - Pattern name in center (flex-1 to take available space)
    - Counter (#{currentIndex + 1} / {totalPatterns}) in center-right
    - Next button (〉) on right
  * Buttons are disabled when at first/last pattern respectively
  * Removed '次の魔法陣 →' buttons from result screen and button panel
  * Updated comments and styling

The pagination controls are only visible when not active (similar to the previous title row), providing a cleaner UI that integrates navigation directly into the title area.
