### PR TITLE
fix: remove save button and fix completion button disable condition (#55)

### DIFF
--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -30,7 +30,7 @@ export default function MagicCircleCanvas({
     difficulty, difficultyLabel, handleEvaluate, handleReset, handleNext, handlePrevious, changeDifficulty,
     getRankColor, onPointerDown, onPointerMove, onPointerUp,
     // リプレイ関連
-    drawLogs, savedMagicData, isReplaying, handleReplay, handleSaveData, handleLoadData,
+    drawLogs, savedMagicData, isReplaying, handleReplay, handleLoadData,
     // 完了追跡
     completionStatus,
     // 音声検知
@@ -300,19 +300,11 @@ export default function MagicCircleCanvas({
       <div className="flex gap-3 flex-wrap justify-center">
         <button
           onClick={handleEvaluate}
-          disabled={userPath.length < 10 || showResult || isReplaying}
+          disabled={showResult || isReplaying}
           className="cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-80"
           style={{ background: 'linear-gradient(135deg, #00e5ff, #7c4dff)' }}
         >
           詠唱完了！
-        </button>
-        <button
-          onClick={() => handleSaveData()}
-          disabled={drawLogs.length === 0}
-          className="cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-80"
-          style={{ background: 'linear-gradient(135deg, #76ff03, #00e5ff)' }}
-        >
-          💾 保存
         </button>
         <button
           onClick={handleReset}

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -142,7 +142,7 @@ export function useMagicCircle(
         stopListening: voiceHook.stopListening
       });
     }
-  }, [voiceHook]);
+  }, [voiceHook?.isMicAccessible, voiceHook?.isListening]);
 
   // ─── パターン・難易度管理 ───
   const [difficulty, setDifficulty] = useState<Difficulty>('normal');


### PR DESCRIPTION
## Changes Made

### 削除 保存ボタン (Removed Save Button)
- Removed the save button (💾 保存) from the MagicCircleCanvas component as requested in issue #55

### 詠唱完了ボタンが押せない不具合の修正 (Fixed Completion Button)
- Modified the completion button (詠唱完了！) disable condition from:
  `disabled={userPath.length < 10 || showResult || isReplaying}`
  to:
  `disabled={showResult || isReplaying}`
- Removed the restrictive `userPath.length < 10` condition that prevented users from attempting to complete their drawing
- The underlying scoring system in `src/lib/scoring.ts` already handles cases with insufficient points by returning a score of 0, making this UI restriction unnecessary

### Additional Fixes
- Fixed infinite loop in `useMagicCircle` hook by correcting `useEffect` dependencies from `[voiceHook]` to `[voiceHook?.isMicAccessible, voiceHook?.isListening]`
- Removed unused `handleSaveData` from component destructuring

## Testing Verified
✅ Save button is no longer visible in the UI
✅ Completion button works immediately after reset (even before drawing)
✅ Completion button properly shows C rank (0 points) when clicked without drawing
✅ Completion button remains disabled appropriately during result display and replay states
✅ No more infinite loop warnings in console

## Related Issue
Closes #55