### PR TITLE
fix: データ形式エラーを修正 - replay後のdrawLogsアクセスにガードを追加 (#68)

### DIFF
--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -35,6 +35,13 @@ function ReplayContent() {
       setLoading(false);
       return;
     }
+    
+    // Validate that drawLogs exists and is an array
+    if (!Array.isArray(decompressedData.data.drawLogs)) {
+      setError('描画データが見つかりません。');
+      setLoading(false);
+      return;
+    }
 
     setHistory(decompressedData);
     setLoading(false);

--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -25,7 +25,8 @@ const CANVAS_SIZE = 350;
  * @param strokes 履歴データの描画ログ
  * @returns 相対タイムスタンプに変換された描画イベントの配列
  */
-function createReplayDrawLogs(strokes: MagicCircleHistory['data']['drawLogs']): DrawEvent[][] {
+function createReplayDrawLogs(strokes: MagicCircleHistory['data']['drawLogs'] | null | undefined): DrawEvent[][] {
+  if (!strokes) return [];
   return strokes.map((stroke) => {
     if (stroke.length === 0) return [];
     const t0 = stroke[0].t;
@@ -88,6 +89,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
     const ctx = canvas.getContext('2d');
     if (!ctx || !history) return;
     if (!history.data) return;
+    if (!history.data.drawLogs) return;
     drawTemplate(history.data.pattern);
 
     const allPoints: { x: number; y: number }[] = [];
@@ -127,6 +129,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       canvasReadyRef.current = true;
       // Draw template + final state immediately
       if (!history.data) return;
+      if (!history.data.drawLogs) return;
       drawTemplate(history.data.pattern);
       const allPoints: { x: number; y: number }[] = [];
       for (const stroke of history.data.drawLogs) {
@@ -187,6 +190,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
     if (!ctx) return;
 
     if (!history.data) return;
+    if (!history.data.drawLogs) return;
 
     const drawLogs = history.data.drawLogs;
     const normalizedLogs = createReplayDrawLogs(drawLogs);
@@ -317,6 +321,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       
       if (!history) return;
       if (!history.data) return;
+      if (!history.data.drawLogs) return;
       drawTemplate(history.data.pattern);
       
       const startTime = performance.now() - clampedTime;
@@ -515,7 +520,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
               {/* Share Button */}
               <button
                 onClick={async () => {
-                  if (history && history.data) {
+                  if (history && history.data && history.data.drawLogs) {
                     try {
                       // Compress the data for URL sharing (only essential data to keep URL short)
                       const shareData = {
@@ -597,7 +602,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
                 {history.data.pattern.name}
               </div>
               <div className="text-xs text-gray-600">
-                {history.data.drawLogs.length}ストローク
+                {history.data.drawLogs ? history.data.drawLogs.length : 0}ストローク
               </div>
             </div>
 


### PR DESCRIPTION
## 変更内容

詠唱完了後のリプレイでデータ形式エラーが発生する問題を修正しました（#68）。

### 問題
- replay後に`history.data.drawLogs`がnullまたは未定義の状態でアクセスしようとすることでランタイムエラーが発生
- 具体的には以下の場所でエラーが発生：
  - drawLogsのループ処理 (`for (const stroke of history.data.drawLogs)`)
  - drawLogs.lengthへのアクセス
  - 描画ログを渡す関数呼び出し

### 修正内容
1. **replayページのバリデーション強化** (`src/app/replay/page.tsx`)
   - drawLogsの存在と配列形式を検証するバリデーションを追加

2. **HistoryDetailコンポーネントのガード追加** (`src/components/HistoryDetail.tsx`)
   - drawAllStroke関数でnullチェック追加
   - canvas refハンドラーでnullチェック追加  
   - handlePlay関数でnullチェック追加
   - handleSeek関数でnullチェック追加
   - シェアボタンの条件にdrawLogsチェック追加
   - パターン情報表示でのdrawLogs.lengthアクセスをガード
   - createReplayDrawLogs関数にnull/undefinedチェック追加

### テスト
- 正常なデータでのリプレイ動作確認
- drawLogsがnull/空の場合のエラーハンドリング確認
- シェア機能の正常動作確認

Fixes #68