### PR TITLE
fix: リプレイURLのデータ形式を MagicCircleHistory 構造に統一 (#72)

### DIFF
--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -22,26 +22,50 @@ function ReplayContent() {
       return;
     }
 
-    const decompressedData = decompressFromUrl<MagicCircleHistory>(dataParam);
-    if (!decompressedData) {
+    // decompressFromUrlOptimized はフラット構造 { pattern, drawLogs, score, ... } を返す
+    const flat = decompressFromUrl<{
+      pattern: MagicCircleHistory['data']['pattern'];
+      drawLogs: MagicCircleHistory['data']['drawLogs'];
+      score: number;
+      rank: string;
+      difficulty: string;
+      difficultyMultiplier: number;
+      damageMultiplier: string;
+    }>(dataParam);
+
+    if (!flat) {
       setError('データの復元に失敗しました。共有リンクが無効または破損している可能性があります。');
       setLoading(false);
       return;
     }
 
-    // Validate that we have the minimum required data structure
-    if (!decompressedData.data || !decompressedData.data.pattern) {
+    if (!flat.pattern) {
       setError('データ形式が不正です。');
       setLoading(false);
       return;
     }
-    
-    // Validate that drawLogs exists and is an array
-    if (!Array.isArray(decompressedData.data.drawLogs)) {
+
+    if (!Array.isArray(flat.drawLogs)) {
       setError('描画データが見つかりません。');
       setLoading(false);
       return;
     }
+
+    // フラット構造から MagicCircleHistory を再構築
+    const decompressedData: MagicCircleHistory = {
+      id: `replay_${Date.now()}`,
+      data: {
+        pattern: flat.pattern,
+        drawLogs: flat.drawLogs,
+        timestamp: Date.now(),
+      },
+      score: flat.score,
+      rank: flat.rank,
+      difficulty: flat.difficulty,
+      difficultyMultiplier: flat.difficultyMultiplier,
+      damageMultiplier: flat.damageMultiplier,
+      createdAt: Date.now(),
+    };
 
     setHistory(decompressedData);
     setLoading(false);

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -650,16 +650,15 @@ export function useMagicCircle(
     try {
       await addHistory(historyItem);
       
-      // URL圧縮用にデータを抽出（thumbnail のみ除外してURLサイズを抑える）
-      const dataForCompression: Omit<MagicCircleHistory, 'thumbnail'> = {
-        id: historyItem.id,
-        data: historyItem.data,
+      // URL圧縮用にデータを抽出（compressForUrlOptimized の期待するフラット構造）
+      const dataForCompression = {
+        pattern: historyItem.data.pattern,
+        drawLogs: historyItem.data.drawLogs,
         score: historyItem.score,
         rank: historyItem.rank,
         difficulty: historyItem.difficulty,
         difficultyMultiplier: historyItem.difficultyMultiplier,
         damageMultiplier: historyItem.damageMultiplier,
-        createdAt: historyItem.createdAt,
       };
       
       // 履歴データをURL用に圧縮

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -650,15 +650,16 @@ export function useMagicCircle(
     try {
       await addHistory(historyItem);
       
-      // URL圧縮用にデータを抽出（メタデータを除いた本体部分のみ）
-      const dataForCompression = {
-        pattern: historyItem.data.pattern,
-        drawLogs: historyItem.data.drawLogs,
+      // URL圧縮用にデータを抽出（thumbnail のみ除外してURLサイズを抑える）
+      const dataForCompression: Omit<MagicCircleHistory, 'thumbnail'> = {
+        id: historyItem.id,
+        data: historyItem.data,
         score: historyItem.score,
         rank: historyItem.rank,
         difficulty: historyItem.difficulty,
         difficultyMultiplier: historyItem.difficultyMultiplier,
-        damageMultiplier: historyItem.damageMultiplier
+        damageMultiplier: historyItem.damageMultiplier,
+        createdAt: historyItem.createdAt,
       };
       
       // 履歴データをURL用に圧縮


### PR DESCRIPTION
handleReplay() でURL圧縮するデータがフラット構造だったため、
replay/page.tsx の `decompressedData.data.pattern` 検証で 「データ形式が不正です」エラーが常に発生していた。

圧縮対象を MagicCircleHistory 構造（thumbnail のみ除外）に変更し、
送受信側の構造を一致させて修正。

Fixes #72