### PR TITLE
fix: 履歴詳細の再生ボタンが機能しない問題を修正 (#74)

### DIFF
--- a/src/components/HistoryDetail.test.tsx
+++ b/src/components/HistoryDetail.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@/lib/shareUtils', () => ({
   compressForUrlOptimized: vi.fn(() => 'compressed'),
@@ -8,17 +8,47 @@ vi.mock('@/lib/shareUtils', () => ({
 import HistoryDetail from './HistoryDetail';
 import type { MagicCircleHistory } from '@/lib/types';
 
+// Canvas 2D context のモック
+const mockCtx = {
+  clearRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  fill: vi.fn(),
+  arc: vi.fn(),
+  setLineDash: vi.fn(),
+  shadowBlur: 0,
+  shadowColor: '',
+  strokeStyle: '',
+  fillStyle: '',
+  lineWidth: 0,
+  lineCap: '',
+  lineJoin: '',
+};
+
+// requestAnimationFrame をモック（アニメーションループを制御）
+const rafCallbacks: FrameRequestCallback[] = [];
+const mockRaf = vi.fn((cb: FrameRequestCallback) => {
+  rafCallbacks.push(cb);
+  return rafCallbacks.length;
+});
+const mockCancelRaf = vi.fn((id: number) => {
+  rafCallbacks.splice(id - 1, 1);
+});
+
 // テスト用の最小履歴データを生成するファクトリ
-function makeHistory(drawLogsLength: number): MagicCircleHistory {
+function makeHistory(drawLogsLength: number, id = 'test-id'): MagicCircleHistory {
   const drawLogs = drawLogsLength > 0
-    ? Array.from({ length: drawLogsLength }, () => [
-        { x: 10, y: 10, t: 0, type: 'start' as const },
-        { x: 20, y: 20, t: 100, type: 'end' as const },
+    ? Array.from({ length: drawLogsLength }, (_, i) => [
+        { x: 10 + i * 10, y: 10, t: i * 200, type: 'start' as const },
+        { x: 20 + i * 10, y: 20, t: i * 200 + 100, type: 'move' as const },
+        { x: 30 + i * 10, y: 30, t: i * 200 + 200, type: 'end' as const },
       ])
     : [];
 
   return {
-    id: 'test-id',
+    id,
     data: {
       seed: 1,
       pattern: {
@@ -53,6 +83,8 @@ function renderDetail(history: MagicCircleHistory | null) {
   );
 }
 
+// ─── disabled 条件テスト ──────────────────────────────────────────────────────
+
 describe('HistoryDetail — リプレイボタン disabled 条件', () => {
 
   beforeEach(() => {
@@ -66,19 +98,98 @@ describe('HistoryDetail — リプレイボタン disabled 条件', () => {
 
   it('drawLogs が空配列のとき再生ボタンが disabled', () => {
     renderDetail(makeHistory(0));
-    const btn = screen.getByRole('button', { name: /▶️ 再生/ });
-    expect(btn).toBeDisabled();
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).toBeDisabled();
   });
 
   it('drawLogs がある場合（1ストローク）再生ボタンが enabled', () => {
     renderDetail(makeHistory(1));
-    const btn = screen.getByRole('button', { name: /▶️ 再生/ });
-    expect(btn).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).not.toBeDisabled();
   });
 
   it('drawLogs が複数ある場合も再生ボタンが enabled', () => {
     renderDetail(makeHistory(3));
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).not.toBeDisabled();
+  });
+});
+
+// ─── 再生ボタン動作テスト ─────────────────────────────────────────────────────
+
+describe('HistoryDetail — 再生ボタン動作', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rafCallbacks.length = 0;
+    vi.stubGlobal('requestAnimationFrame', mockRaf);
+    vi.stubGlobal('cancelAnimationFrame', mockCancelRaf);
+    // Canvas getContext を有効な mock context を返すよう上書き
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLCanvasElement.prototype as any).getContext = () => mockCtx;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // setup.ts の元のモックに戻す
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLCanvasElement.prototype as any).getContext = () => null;
+  });
+
+  it('▶️ 再生ボタンを押すと ⏸️ 一時停止 に変わる', () => {
+    renderDetail(makeHistory(2));
     const btn = screen.getByRole('button', { name: /▶️ 再生/ });
-    expect(btn).not.toBeDisabled();
+
+    act(() => { fireEvent.click(btn); });
+
+    expect(screen.getByRole('button', { name: /⏸️ 一時停止/ })).toBeTruthy();
+  });
+
+  it('⏸️ 一時停止ボタンを押すと ▶️ 再生 に戻る', () => {
+    renderDetail(makeHistory(2));
+    const playBtn = screen.getByRole('button', { name: /▶️ 再生/ });
+
+    act(() => { fireEvent.click(playBtn); });
+    const pauseBtn = screen.getByRole('button', { name: /⏸️ 一時停止/ });
+    act(() => { fireEvent.click(pauseBtn); });
+
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).toBeTruthy();
+  });
+
+  it('history が変わると再生状態がリセットされる（Bug 1 修正確認）', () => {
+    const { rerender } = renderDetail(makeHistory(2, 'history-a'));
+    const btn = screen.getByRole('button', { name: /▶️ 再生/ });
+
+    // 再生開始
+    act(() => { fireEvent.click(btn); });
+    expect(screen.getByRole('button', { name: /⏸️ 一時停止/ })).toBeTruthy();
+
+    // 別の履歴に切り替え
+    act(() => {
+      rerender(
+        <HistoryDetail
+          history={makeHistory(2, 'history-b')}
+          onClose={vi.fn()}
+          onReEdit={vi.fn()}
+        />
+      );
+    });
+
+    // 再生状態がリセットされ ▶️ 再生 に戻っている
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).toBeTruthy();
+  });
+
+  it('history が null になると再生状態がリセットされモーダルが消える', () => {
+    const { rerender } = renderDetail(makeHistory(2));
+    act(() => { fireEvent.click(screen.getByRole('button', { name: /▶️ 再生/ })); });
+
+    act(() => {
+      rerender(
+        <HistoryDetail
+          history={null}
+          onClose={vi.fn()}
+          onReEdit={vi.fn()}
+        />
+      );
+    });
+
+    expect(screen.queryByRole('button', { name: /再生|一時停止/ })).toBeNull();
   });
 });

--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -168,17 +168,15 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
     };
   }, []);
 
-  // Reset playback state when history changes
+  // history が変わるたびに再生状態をリセット（null → 別アイテムも含む）
   useEffect(() => {
-    if (!history) {
-      setIsPlaying(false);
-      setCurrentTime(0);
-      setTotalDuration(0);
-      setStartTime(null);
-      if (replayAnimRef.current !== null) {
-        cancelAnimationFrame(replayAnimRef.current);
-        replayAnimRef.current = null;
-      }
+    setIsPlaying(false);
+    setCurrentTime(0);
+    setTotalDuration(0);
+    setStartTime(null);
+    if (replayAnimRef.current !== null) {
+      cancelAnimationFrame(replayAnimRef.current);
+      replayAnimRef.current = null;
     }
   }, [history]);
 
@@ -213,7 +211,10 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
 
     drawTemplate(history.data.pattern);
 
-    const startTime = performance.now() - currentTime;
+    // 再生完了後に再度押した場合は最初から再生する
+    const startFrom = currentTime >= totalDuration ? 0 : currentTime;
+    if (startFrom === 0) setCurrentTime(0);
+    const startTime = performance.now() - startFrom;
     setStartTime(startTime);
     setIsPlaying(true);
     setDebugMsg('🔄 再生中...');


### PR DESCRIPTION
【Bug 1】history が変わっても currentTime がリセットされない
- useEffect の条件を「history が null のとき」から「history が変わるたびに」に変更
- 別の履歴アイテムに切り替えたとき currentTime/totalDuration/isPlaying をリセット

【Bug 2】再生完了後に再度▶️を押すとすぐ終了する
- handlePlay 内で currentTime >= totalDuration のとき startFrom を 0 にリセット
- これにより完了後の再プレイが最初から始まる

テストケースを追加:
- ▶️ 再生ボタンを押すと ⏸️ 一時停止 に変わることを確認
- ⏸️ 一時停止を押すと ▶️ 再生 に戻ることを確認
- history 切り替え時に再生状態がリセットされることを確認（Bug 1 修正確認）
- history が null になるとモーダルが消えることを確認

Fixes #74