### PR TITLE
fix: 線のshadowBlurを全箇所で1割程度に削減 (#75)

### DIFF
--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -99,7 +99,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       }
     }
     if (allPoints.length > 1) {
-      ctx.shadowBlur = 15;
+      ctx.shadowBlur = 2;
       ctx.shadowColor = '#00e5ff';
       ctx.strokeStyle = '#00e5ff';
       ctx.lineWidth = 4;
@@ -140,7 +140,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       if (allPoints.length > 1) {
         const ctx = node.getContext('2d');
         if (ctx) {
-          ctx.shadowBlur = 15;
+          ctx.shadowBlur = 2;
           ctx.shadowColor = '#00e5ff';
           ctx.strokeStyle = '#00e5ff';
           ctx.lineWidth = 4;
@@ -233,7 +233,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       }
 
       if (pts.length > 1) {
-        ctx.shadowBlur = 15;
+        ctx.shadowBlur = 2;
         ctx.shadowColor = '#00e5ff';
         ctx.strokeStyle = '#00e5ff';
         ctx.lineWidth = 4;
@@ -249,13 +249,13 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
 
         // Leading glow
         const last = pts[pts.length - 1];
-        ctx.shadowBlur = 20;
+        ctx.shadowBlur = 2;
         ctx.shadowColor = '#00e5ff';
         ctx.fillStyle = '#ffffff';
         ctx.beginPath();
         ctx.arc(last.x, last.y, 6, 0, Math.PI * 2);
         ctx.fill();
-        ctx.shadowBlur = 8;
+        ctx.shadowBlur = 1;
         ctx.fillStyle = '#00e5ff';
         ctx.beginPath();
         ctx.arc(last.x, last.y, 10, 0, Math.PI * 2);
@@ -267,7 +267,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
         if (!history.data) return;
         drawTemplate(history.data.pattern);
         if (pts.length > 1) {
-          ctx.shadowBlur = 15;
+          ctx.shadowBlur = 2;
           ctx.shadowColor = '#00e5ff';
           ctx.strokeStyle = '#00e5ff';
           ctx.lineWidth = 4;
@@ -358,7 +358,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
         }
         
         if (pts.length > 1) {
-          ctx.shadowBlur = 15;
+          ctx.shadowBlur = 2;
           ctx.shadowColor = '#00e5ff';
           ctx.strokeStyle = '#00e5ff';
           ctx.lineWidth = 4;
@@ -374,13 +374,13 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
           
           // Leading glow
           const last = pts[pts.length - 1];
-          ctx.shadowBlur = 20;
+          ctx.shadowBlur = 2;
           ctx.shadowColor = '#00e5ff';
           ctx.fillStyle = '#ffffff';
           ctx.beginPath();
           ctx.arc(last.x, last.y, 6, 0, Math.PI * 2);
           ctx.fill();
-          ctx.shadowBlur = 8;
+          ctx.shadowBlur = 1;
           ctx.fillStyle = '#00e5ff';
           ctx.beginPath();
           ctx.arc(last.x, last.y, 10, 0, Math.PI * 2);
@@ -392,7 +392,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
           if (!history.data) return;
           drawTemplate(history.data.pattern);
           if (pts.length > 1) {
-            ctx.shadowBlur = 15;
+            ctx.shadowBlur = 2;
             ctx.shadowColor = '#00e5ff';
             ctx.strokeStyle = '#00e5ff';
             ctx.lineWidth = 4;

--- a/src/components/TutorialCanvasAnimation.tsx
+++ b/src/components/TutorialCanvasAnimation.tsx
@@ -98,13 +98,13 @@ export default function TutorialCanvasAnimation() {
           drawGlowEdge(ctx, edge.from, { x: currentX, y: currentY });
 
           // 先端の光点
-          ctx.shadowBlur = 20;
+          ctx.shadowBlur = 2;
           ctx.shadowColor = '#00e5ff';
           ctx.fillStyle = '#ffffff';
           ctx.beginPath();
           ctx.arc(currentX, currentY, 6, 0, Math.PI * 2);
           ctx.fill();
-          ctx.shadowBlur = 8;
+          ctx.shadowBlur = 1;
           ctx.fillStyle = '#00e5ff';
           ctx.beginPath();
           ctx.arc(currentX, currentY, 10, 0, Math.PI * 2);
@@ -173,7 +173,7 @@ function drawGlowEdge(
   from: { x: number; y: number },
   to: { x: number; y: number },
 ) {
-  ctx.shadowBlur = 12;
+  ctx.shadowBlur = 1;
   ctx.shadowColor = '#00e5ff';
   ctx.strokeStyle = '#00e5ff';
   ctx.lineWidth = 3;

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -335,7 +335,7 @@ export function useMagicCircle(
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     
-    ctx.shadowBlur = 15;
+    ctx.shadowBlur = 2;
     ctx.shadowColor = '#00e5ff';
     ctx.strokeStyle = '#00e5ff';
     ctx.lineWidth = 4;


### PR DESCRIPTION
- useMagicCircle.ts: 15 → 2
- HistoryDetail.tsx: 線15→2、先端グロー球20→2、先端グロー円8→1
- TutorialCanvasAnimation.tsx: 先端20→2、先端円8→1、drawGlowEdge12→1