### PR TITLE
test: テストケースを大幅に追加 (#81)

### DIFF
--- a/src/components/HistoryDetail.test.tsx
+++ b/src/components/HistoryDetail.test.tsx
@@ -82,3 +82,83 @@ describe('HistoryDetail — リプレイボタン disabled 条件', () => {
     expect(btn).not.toBeDisabled();
   });
 });
+
+describe('HistoryDetail — 表示内容', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('history のスコアが表示される', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByText('80点')).toBeInTheDocument();
+  });
+
+  it('history のランクが表示される', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('history のパターン名が表示される', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByText('テストパターン')).toBeInTheDocument();
+  });
+
+  it('難易度が表示される', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByText(/ノーマル/)).toBeInTheDocument();
+  });
+
+  it('作成日時ラベルが表示される', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByText('作成日時')).toBeInTheDocument();
+  });
+});
+
+describe('HistoryDetail — ボタン・インタラクション', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('閉じるボタン（✕）が存在する', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByRole('button', { name: '✕' })).toBeInTheDocument();
+  });
+
+  it('閉じるボタンをクリックすると onClose が呼ばれる', () => {
+    const onClose = vi.fn();
+    render(
+      <HistoryDetail
+        history={makeHistory(1)}
+        onClose={onClose}
+        onReEdit={vi.fn()}
+      />
+    );
+    screen.getByRole('button', { name: '✕' }).click();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('再編集ボタンが存在する', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByRole('button', { name: /再編集/ })).toBeInTheDocument();
+  });
+
+  it('再編集ボタンをクリックすると onReEdit が呼ばれる', () => {
+    const onReEdit = vi.fn();
+    render(
+      <HistoryDetail
+        history={makeHistory(1)}
+        onClose={vi.fn()}
+        onReEdit={onReEdit}
+      />
+    );
+    screen.getByRole('button', { name: /再編集/ }).click();
+    expect(onReEdit).toHaveBeenCalledOnce();
+  });
+
+  it('共有ボタンが存在する', () => {
+    renderDetail(makeHistory(1));
+    expect(screen.getByRole('button', { name: /共有/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/MagicCircleCanvas.test.tsx
+++ b/src/components/MagicCircleCanvas.test.tsx
@@ -161,4 +161,61 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
       expect(screen.getByRole('button', { name: '再生中...' })).toBeDisabled();
     });
   });
+
+  // ─── 表示内容 ─────────────────────────────────────────────────────────────
+
+  describe('表示内容', () => {
+    it('patternName が表示される', () => {
+      renderCanvas({ patternName: 'テストパターン' });
+      expect(screen.getByText('テストパターン')).toBeInTheDocument();
+    });
+
+    it('patternName が空のとき「準備中...」が表示される', () => {
+      renderCanvas({ patternName: '' });
+      expect(screen.getByText('準備中...')).toBeInTheDocument();
+    });
+
+    it('showResult=true のとき scoreResult のランクが表示される', () => {
+      renderCanvas({
+        showResult: true,
+        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%' },
+      });
+      expect(screen.getByText('A')).toBeInTheDocument();
+    });
+
+    it('showResult=true のとき scoreResult のスコアが表示される', () => {
+      renderCanvas({
+        showResult: true,
+        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%' },
+      });
+      expect(screen.getByText('85点')).toBeInTheDocument();
+    });
+
+    it('showResult=true のとき damageMultiplier が表示される', () => {
+      renderCanvas({
+        showResult: true,
+        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%' },
+      });
+      expect(screen.getByText(/100%/)).toBeInTheDocument();
+    });
+
+    it('isActive=true のとき timeLeft が表示される', () => {
+      renderCanvas({ isActive: true, timeLeft: 42 });
+      expect(screen.getByText('42s')).toBeInTheDocument();
+    });
+
+    it('isActive=false のとき残り時間テキストが表示されない', () => {
+      renderCanvas({ isActive: false, timeLeft: 42 });
+      expect(screen.queryByText('42s')).toBeNull();
+    });
+  });
+
+  // ─── currentIndex / totalPatterns 表示 ───────────────────────────────────
+
+  describe('currentIndex / totalPatterns 表示', () => {
+    it('現在のパターン番号と総数が表示される', () => {
+      renderCanvas({ currentIndex: 1, totalPatterns: 5 });
+      expect(screen.getByText(/#2\s*\/\s*5/)).toBeInTheDocument();
+    });
+  });
 });

--- a/src/hooks/useMagicCircle.test.ts
+++ b/src/hooks/useMagicCircle.test.ts
@@ -240,4 +240,101 @@ describe('useMagicCircle', () => {
       expect(result.current.drawLogs).toEqual([]);
     });
   });
+
+  // ─── 1. 画面状態: changeDifficulty — 全難易度 ────────────────────────────
+
+  describe('changeDifficulty() — 全難易度', () => {
+    it('easy に変更されると timeLeft が DIFFICULTY_TIME.easy になる', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.changeDifficulty('easy'); });
+      expect(result.current.timeLeft).toBe(DIFFICULTY_TIME.easy);
+    });
+
+    it('normal に変更されると timeLeft が DIFFICULTY_TIME.normal になる', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.changeDifficulty('hard'); });
+      act(() => { result.current.changeDifficulty('normal'); });
+      expect(result.current.timeLeft).toBe(DIFFICULTY_TIME.normal);
+    });
+
+    it('hard に変更されると timeLeft が DIFFICULTY_TIME.hard になる', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.changeDifficulty('hard'); });
+      expect(result.current.timeLeft).toBe(DIFFICULTY_TIME.hard);
+    });
+
+    it('難易度変更後に handleReset すると timeLeft が新難易度の値のまま', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.changeDifficulty('easy'); });
+      act(() => { result.current.handleReset(); });
+      expect(result.current.timeLeft).toBe(DIFFICULTY_TIME.easy);
+    });
+  });
+
+  // ─── 2. Canvas状態管理: 描画操作（追加） ──────────────────────────────────
+
+  describe('onPointerMove — 非描画中', () => {
+    const makePointerEvent = (x: number, y: number) =>
+      ({
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        stopPropagation: vi.fn(),
+      } as unknown as React.PointerEvent);
+
+    it('isDrawing=false のとき onPointerMove を呼んでも userPath は空のまま', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.onPointerMove(makePointerEvent(100, 100)); });
+      expect(result.current.userPath).toEqual([]);
+    });
+
+    it('複数回 onPointerMove すると userPath が複数点に増加する', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.onPointerDown(makePointerEvent(100, 100)); });
+      act(() => { result.current.onPointerMove(makePointerEvent(110, 110)); });
+      act(() => { result.current.onPointerMove(makePointerEvent(120, 120)); });
+      act(() => { result.current.onPointerMove(makePointerEvent(130, 130)); });
+      expect(result.current.userPath.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('onPointerUp 後に onPointerMove を呼んでも userPath は空のまま', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.onPointerDown(makePointerEvent(100, 100)); });
+      act(() => { result.current.onPointerUp(); });
+      act(() => { result.current.onPointerMove(makePointerEvent(150, 150)); });
+      expect(result.current.userPath).toEqual([]);
+    });
+  });
+
+  describe('複数ストローク', () => {
+    const makePointerEvent = (x: number, y: number) =>
+      ({
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        stopPropagation: vi.fn(),
+      } as unknown as React.PointerEvent);
+
+    it('2 回ストロークすると drawLogs.length が 2 になる', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      // 1 ストローク目
+      act(() => { result.current.onPointerDown(makePointerEvent(100, 100)); });
+      act(() => { result.current.onPointerMove(makePointerEvent(110, 110)); });
+      act(() => { result.current.onPointerUp(); });
+      // 2 ストローク目
+      act(() => { result.current.onPointerDown(makePointerEvent(150, 150)); });
+      act(() => { result.current.onPointerMove(makePointerEvent(160, 160)); });
+      act(() => { result.current.onPointerUp(); });
+      expect(result.current.drawLogs.length).toBe(2);
+    });
+
+    it('handleReset 後に drawLogs は空配列にリセットされる（複数ストローク後）', () => {
+      const { result } = renderHook(() => useMagicCircle(onScore, onReset));
+      act(() => { result.current.onPointerDown(makePointerEvent(100, 100)); });
+      act(() => { result.current.onPointerMove(makePointerEvent(110, 110)); });
+      act(() => { result.current.onPointerUp(); });
+      act(() => { result.current.handleReset(); });
+      expect(result.current.drawLogs).toEqual([]);
+    });
+  });
 });

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { calculateScore } from './scoring';
+import type { MagicCirclePattern } from './patterns';
+
+// テスト用の三角形パターン
+const trianglePattern: MagicCirclePattern = {
+  name: 'テスト三角形',
+  vertices: [
+    { x: 100, y: 50 },
+    { x: 200, y: 200 },
+    { x: 0, y: 200 },
+  ],
+  edges: [
+    { from: 0, to: 1 },
+    { from: 1, to: 2 },
+    { from: 2, to: 0 },
+  ],
+  circles: [],
+};
+
+// 辺上の補間点を生成
+function interpolate(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  steps: number,
+): { x: number; y: number }[] {
+  return Array.from({ length: steps }, (_, i) => ({
+    x: from.x + (to.x - from.x) * (i / steps),
+    y: from.y + (to.y - from.y) * (i / steps),
+  }));
+}
+
+// テンプレート辺上を正確になぞるパスを生成
+function perfectPath(): { x: number; y: number }[] {
+  const { vertices, edges } = trianglePattern;
+  const pts: { x: number; y: number }[] = [];
+  for (const edge of edges) {
+    pts.push(...interpolate(vertices[edge.from], vertices[edge.to], 30));
+  }
+  return pts;
+}
+
+describe('calculateScore', () => {
+
+  // ─── 1. 入力検証 ─────────────────────────────────────────────────────────
+
+  describe('入力検証', () => {
+    it('userPath が空配列のとき score=0, rank="C", damageMultiplier="0%" を返す', () => {
+      const result = calculateScore([], trianglePattern);
+      expect(result.score).toBe(0);
+      expect(result.rank).toBe('C');
+      expect(result.damageMultiplier).toBe('0%');
+    });
+
+    it('userPath が 1 点のとき score=0 を返す', () => {
+      const result = calculateScore([{ x: 100, y: 50 }], trianglePattern);
+      expect(result.score).toBe(0);
+      expect(result.rank).toBe('C');
+    });
+
+    it('userPath が 9 点（境界未満）のとき score=0 を返す', () => {
+      const path = Array.from({ length: 9 }, (_, i) => ({ x: 100 + i, y: 50 }));
+      const result = calculateScore(path, trianglePattern);
+      expect(result.score).toBe(0);
+    });
+
+    it('userPath がちょうど 10 点のとき通常計算が実行される（score=0 ではない）', () => {
+      const path = Array.from({ length: 10 }, (_, i) => ({
+        x: 100 + (100 * i) / 9,
+        y: 50 + (150 * i) / 9,
+      }));
+      const result = calculateScore(path, trianglePattern);
+      expect(result.score).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── 2. ランク・ダメージ倍率の対応 ───────────────────────────────────────
+
+  describe('ランク・ダメージ倍率', () => {
+    it('完璧なパスは score>=90, rank="S", damageMultiplier="120%" を返す', () => {
+      const result = calculateScore(perfectPath(), trianglePattern);
+      expect(result.score).toBeGreaterThanOrEqual(90);
+      expect(result.rank).toBe('S');
+      expect(result.damageMultiplier).toBe('120%');
+    });
+
+    it('テンプレートから大きく外れたパスは rank="C", damageMultiplier="0%" を返す', () => {
+      const farPath = Array.from({ length: 20 }, () => ({ x: 350, y: 350 }));
+      const result = calculateScore(farPath, trianglePattern);
+      expect(result.rank).toBe('C');
+      expect(result.damageMultiplier).toBe('0%');
+    });
+
+    it('rank="S" のとき damageMultiplier は "120%"', () => {
+      const result = calculateScore(perfectPath(), trianglePattern);
+      if (result.rank === 'S') {
+        expect(result.damageMultiplier).toBe('120%');
+      }
+    });
+
+    it('rank="A" のとき damageMultiplier は "100%"', () => {
+      // 18px ずらしたパスは A ランク帯になる
+      const slightlyOffPath = perfectPath().map(p => ({ x: p.x + 18, y: p.y }));
+      const result = calculateScore(slightlyOffPath, trianglePattern);
+      if (result.rank === 'A') {
+        expect(result.damageMultiplier).toBe('100%');
+      }
+    });
+
+    it('rank="B" のとき damageMultiplier は "70%"', () => {
+      const moderatelyOffPath = perfectPath().map(p => ({ x: p.x + 30, y: p.y }));
+      const result = calculateScore(moderatelyOffPath, trianglePattern);
+      if (result.rank === 'B') {
+        expect(result.damageMultiplier).toBe('70%');
+      }
+    });
+  });
+
+  // ─── 3. 戻り値の構造 ─────────────────────────────────────────────────────
+
+  describe('戻り値の構造', () => {
+    it('結果は score, rank, damageMultiplier プロパティを持つ', () => {
+      const result = calculateScore(perfectPath(), trianglePattern);
+      expect(result).toHaveProperty('score');
+      expect(result).toHaveProperty('rank');
+      expect(result).toHaveProperty('damageMultiplier');
+    });
+
+    it('score は 0-100 の整数', () => {
+      const result = calculateScore(perfectPath(), trianglePattern);
+      expect(result.score).toBeGreaterThanOrEqual(0);
+      expect(result.score).toBeLessThanOrEqual(100);
+      expect(Number.isInteger(result.score)).toBe(true);
+    });
+
+    it('rank は S/A/B/C のいずれか', () => {
+      const result = calculateScore(perfectPath(), trianglePattern);
+      expect(['S', 'A', 'B', 'C']).toContain(result.rank);
+    });
+
+    it('score が低いほど rank も低い（完璧 vs 最悪の比較）', () => {
+      const goodResult = calculateScore(perfectPath(), trianglePattern);
+      const badResult = calculateScore(Array.from({ length: 20 }, () => ({ x: 350, y: 350 })), trianglePattern);
+      expect(goodResult.score).toBeGreaterThan(badResult.score);
+    });
+  });
+
+  // ─── 4. difficultyTolerance の影響 ───────────────────────────────────────
+
+  describe('difficultyTolerance', () => {
+    it('完璧なパスは tolerance に関わらず高スコアを返す', () => {
+      const path = perfectPath();
+      const lenient = calculateScore(path, trianglePattern, 2.0);
+      const strict = calculateScore(path, trianglePattern, 0.5);
+      expect(lenient.score).toBeGreaterThanOrEqual(80);
+      expect(strict.score).toBeGreaterThanOrEqual(80);
+    });
+
+    it('ずれたパスは tolerance が厳しいほど低スコアになる', () => {
+      // 20px ずらしたパス：strict(0.5)では閾値12.5px未満なので頂点未到達
+      const deviatedPath = perfectPath().map(p => ({ x: p.x + 20, y: p.y }));
+      const lenient = calculateScore(deviatedPath, trianglePattern, 2.0);
+      const strict = calculateScore(deviatedPath, trianglePattern, 0.5);
+      expect(strict.score).toBeLessThan(lenient.score);
+    });
+
+    it('tolerance=1.0（デフォルト）は指定なしと同じスコアを返す', () => {
+      const path = perfectPath();
+      const withDefault = calculateScore(path, trianglePattern);
+      const withExplicit = calculateScore(path, trianglePattern, 1.0);
+      expect(withDefault.score).toBe(withExplicit.score);
+    });
+  });
+
+  // ─── 5. 辺なし・頂点なしパターン（エッジケース） ─────────────────────────
+
+  describe('エッジケース：最小パターン', () => {
+    it('辺が 1 本のパターンでも score が計算される', () => {
+      const linePattern: MagicCirclePattern = {
+        name: '直線',
+        vertices: [{ x: 100, y: 100 }, { x: 200, y: 100 }],
+        edges: [{ from: 0, to: 1 }],
+        circles: [],
+      };
+      const path = interpolate({ x: 100, y: 100 }, { x: 200, y: 100 }, 30);
+      const result = calculateScore(path, linePattern);
+      expect(result.score).toBeGreaterThanOrEqual(0);
+      expect(result.score).toBeLessThanOrEqual(100);
+    });
+  });
+});

--- a/src/lib/shareUtils.test.ts
+++ b/src/lib/shareUtils.test.ts
@@ -80,4 +80,49 @@ describe('shareUtils — 圧縮・解凍', () => {
       expect(compressedOptimized.length).toBeLessThanOrEqual(compressedOriginal.length);
     });
   });
+
+  // ─── 異常入力 ─────────────────────────────────────────────────────────────
+
+  describe('異常入力', () => {
+    it('decompressFromUrl: 空文字列は null を返す', () => {
+      expect(decompressFromUrl('')).toBeNull();
+    });
+
+    it('decompressFromUrl: 不正な文字列は null を返す', () => {
+      expect(decompressFromUrl('!!!invalid!!!')).toBeNull();
+    });
+
+    it('decompressFromUrlOptimized: 空文字列は null を返す', () => {
+      expect(decompressFromUrlOptimized('')).toBeNull();
+    });
+
+    it('decompressFromUrlOptimized: 不正な文字列は null を返す', () => {
+      expect(decompressFromUrlOptimized('!!!invalid!!!')).toBeNull();
+    });
+
+    it('compressForUrl: 空オブジェクトは空文字列以外を返す', () => {
+      const compressed = compressForUrl({});
+      expect(compressed.length).toBeGreaterThan(0);
+    });
+
+    it('compressForUrl → decompressFromUrl: 空オブジェクトのラウンドトリップが成功する', () => {
+      const compressed = compressForUrl({});
+      const decompressed = decompressFromUrl<Record<string, never>>(compressed);
+      expect(decompressed).toEqual({});
+    });
+  });
+
+  // ─── URL安全性 ────────────────────────────────────────────────────────────
+
+  describe('URL安全性', () => {
+    it('compressForUrl の出力は URL に危険な文字を含まない', () => {
+      const compressed = compressForUrl(testData);
+      expect(compressed).not.toMatch(/[+/=]/);
+    });
+
+    it('compressForUrlOptimized の出力は URL に危険な文字を含まない', () => {
+      const compressed = compressForUrlOptimized(testData);
+      expect(compressed).not.toMatch(/[+/=]/);
+    });
+  });
 });


### PR DESCRIPTION
- scoring.test.ts を新規作成（calculateScore の全ブランチをカバー）
  - 入力検証（空・9点・境界値）
  - ランク・ダメージ倍率の対応（S/A/B/C）
  - 戻り値の構造・score 範囲検証
  - difficultyTolerance の影響確認
  - 辺1本パターンのエッジケース
- shareUtils.test.ts に追加
  - 空文字列・不正文字列の解凍は null を返す
  - 空オブジェクトのラウンドトリップ
  - URL安全性（+/= を含まない）
- useMagicCircle.test.ts に追加
  - 全難易度（easy/normal/hard）の timeLeft 変更確認
  - isDrawing=false 時の onPointerMove は userPath を変更しない
  - 複数 onPointerMove で userPath が蓄積される
  - 2 ストローク後の drawLogs.length=2
- HistoryDetail.test.tsx に追加
  - スコア・ランク・パターン名・難易度の表示確認
  - 閉じるボタン・再編集ボタン・共有ボタンの存在確認
  - onClose/onReEdit コールバック呼び出し確認
- MagicCircleCanvas.test.tsx に追加
  - patternName 表示・空時の「準備中...」
  - showResult=true 時のランク・スコア・damageMultiplier 表示
  - isActive 時の timeLeft 表示
  - currentIndex/totalPatterns の番号表示