### PR TITLE
feat: tutorial auto-display and unit tests for issue #77

### DIFF
--- a/src/components/MagicCircleCanvas.test.tsx
+++ b/src/components/MagicCircleCanvas.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { UseMagicCircleReturn } from '@/hooks/useMagicCircle';
 
 // useMagicCircle フックをモック
@@ -9,7 +9,14 @@ vi.mock('@/hooks/useMagicCircle');
 vi.mock('./HelpModal', () => ({ default: () => null }));
 vi.mock('./HistoryPanel', () => ({ default: () => null }));
 vi.mock('./HistoryDetail', () => ({ default: () => null }));
-vi.mock('./TutorialOverlay', () => ({ default: () => null }));
+// TutorialOverlay は存在検出のため data-testid を返すモック
+vi.mock('./TutorialOverlay', () => ({
+  default: ({ onStart }: { onStart: () => void }) => (
+    <div data-testid="tutorial-overlay">
+      <button onClick={onStart}>tutorial-start</button>
+    </div>
+  ),
+}));
 
 import { useMagicCircle } from '@/hooks/useMagicCircle';
 import MagicCircleCanvas from './MagicCircleCanvas';
@@ -160,5 +167,51 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
       });
       expect(screen.getByRole('button', { name: '再生中...' })).toBeDisabled();
     });
+  });
+});
+
+// ─── チュートリアル自動表示テスト ────────────────────────────────────────────
+
+describe('MagicCircleCanvas — チュートリアル自動表示', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockUseMagicCircle.mockReturnValue(defaultMockReturn);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('localStorage に tutorialCompleted がない場合にチュートリアルが表示される', () => {
+    render(
+      <MagicCircleCanvas onScore={vi.fn()} onReset={vi.fn()} initialDifficulty="normal" />
+    );
+    expect(screen.getByTestId('tutorial-overlay')).toBeTruthy();
+  });
+
+  it('localStorage に tutorialCompleted がある場合はチュートリアルが表示されない', () => {
+    localStorage.setItem('tutorialCompleted', '1');
+    render(
+      <MagicCircleCanvas onScore={vi.fn()} onReset={vi.fn()} initialDifficulty="normal" />
+    );
+    expect(screen.queryByTestId('tutorial-overlay')).toBeNull();
+  });
+
+  it('チュートリアル完了後に localStorage に tutorialCompleted が保存される', () => {
+    render(
+      <MagicCircleCanvas onScore={vi.fn()} onReset={vi.fn()} initialDifficulty="normal" />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'tutorial-start' }));
+    expect(localStorage.getItem('tutorialCompleted')).toBe('1');
+  });
+
+  it('チュートリアル完了後にオーバーレイが消える', () => {
+    render(
+      <MagicCircleCanvas onScore={vi.fn()} onReset={vi.fn()} initialDifficulty="normal" />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'tutorial-start' }));
+    expect(screen.queryByTestId('tutorial-overlay')).toBeNull();
   });
 });

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -57,6 +57,21 @@ export default function MagicCircleCanvas({
   const [showHistory, setShowHistory] = useState(false);
   const [selectedHistory, setSelectedHistory] = useState<MagicCircleHistory | null>(null);
 
+  // 初回訪問時にチュートリアルを自動表示
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !localStorage.getItem('tutorialCompleted')) {
+      setShowTutorial(true);
+    }
+  }, []);
+
+  // チュートリアル完了時に localStorage にフラグを保存
+  const handleTutorialComplete = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('tutorialCompleted', '1');
+    }
+    setShowTutorial(false);
+  }, []);
+
   // Sync external difficulty prop
   useEffect(() => { changeDifficulty(initialDifficulty); }, [initialDifficulty, changeDifficulty]);
 
@@ -91,7 +106,7 @@ export default function MagicCircleCanvas({
   return (
     <div className="flex flex-col items-center gap-4 p-4">
       {showTutorial && (
-        <TutorialOverlay onStart={() => setShowTutorial(false)} />
+        <TutorialOverlay onStart={handleTutorialComplete} />
       )}
       {showHelp && <HelpModal onClose={() => setShowHelp(false)} />}
 

--- a/src/components/TutorialOverlay.test.tsx
+++ b/src/components/TutorialOverlay.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// TutorialCanvasAnimation は canvas API を使うためモック
+vi.mock('./TutorialCanvasAnimation', () => ({
+  default: () => <div data-testid="tutorial-canvas-animation" />,
+}));
+
+import TutorialOverlay from './TutorialOverlay';
+
+const TOTAL_STEPS = 4;
+
+function renderOverlay(onStart = vi.fn()) {
+  return render(<TutorialOverlay onStart={onStart} />);
+}
+
+describe('TutorialOverlay', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── 初期表示 ──────────────────────────────────────────────────────────────
+
+  describe('初期表示（ステップ 0）', () => {
+    it('ウェルカムタイトルが表示される', () => {
+      renderOverlay();
+      expect(screen.getByText(/Arcane Tracerへようこそ/)).toBeTruthy();
+    });
+
+    it('ボタンテキストが「次へ →」', () => {
+      renderOverlay();
+      expect(screen.getByRole('button', { name: /次へ/ })).toBeTruthy();
+    });
+
+    it('TutorialCanvasAnimation はステップ 0 では表示されない', () => {
+      renderOverlay();
+      expect(screen.queryByTestId('tutorial-canvas-animation')).toBeNull();
+    });
+
+    it(`プログレスドットが ${TOTAL_STEPS} 個表示される`, () => {
+      const { container } = renderOverlay();
+      const dots = container.querySelectorAll('.rounded-full.h-2.w-2');
+      expect(dots).toHaveLength(TOTAL_STEPS);
+    });
+
+    it('ステップ 0 のドットが cyan でハイライトされる', () => {
+      const { container } = renderOverlay();
+      const dots = Array.from(container.querySelectorAll('.rounded-full.h-2.w-2'));
+      // jsdom は #00e5ff を rgb(0, 229, 255) に変換する
+      expect((dots[0] as HTMLElement).style.background).toContain('rgb(0, 229, 255)');
+    });
+  });
+
+  // ─── ステップ遷移 ──────────────────────────────────────────────────────────
+
+  describe('ステップ遷移', () => {
+    it('「次へ」をクリックするとステップ 1 のタイトルが表示される', () => {
+      renderOverlay();
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ }));
+      expect(screen.getByText(/手順/)).toBeTruthy();
+    });
+
+    it('ステップ 2（アニメーション）で TutorialCanvasAnimation が表示される', () => {
+      renderOverlay();
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ })); // step 1
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ })); // step 2
+      expect(screen.getByTestId('tutorial-canvas-animation')).toBeTruthy();
+    });
+
+    it('ステップ 2 を超えると TutorialCanvasAnimation が消える', () => {
+      renderOverlay();
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ })); // step 1
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ })); // step 2
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ })); // step 3
+      expect(screen.queryByTestId('tutorial-canvas-animation')).toBeNull();
+    });
+
+    it(`ステップ ${TOTAL_STEPS - 1}（最終）でボタンが「始める」に変わる`, () => {
+      renderOverlay();
+      for (let i = 0; i < TOTAL_STEPS - 1; i++) {
+        fireEvent.click(screen.getByRole('button', { name: /次へ|始める/ }));
+      }
+      expect(screen.getByRole('button', { name: /始める/ })).toBeTruthy();
+    });
+
+    it('最終ステップで「始める」をクリックすると onStart が呼ばれる', () => {
+      const onStart = vi.fn();
+      renderOverlay(onStart);
+      for (let i = 0; i < TOTAL_STEPS - 1; i++) {
+        fireEvent.click(screen.getByRole('button', { name: /次へ|始める/ }));
+      }
+      fireEvent.click(screen.getByRole('button', { name: /始める/ }));
+      expect(onStart).toHaveBeenCalledOnce();
+    });
+
+    it('最終ステップ前に onStart は呼ばれない', () => {
+      const onStart = vi.fn();
+      renderOverlay(onStart);
+      for (let i = 0; i < TOTAL_STEPS - 1; i++) {
+        fireEvent.click(screen.getByRole('button', { name: /次へ|始める/ }));
+      }
+      expect(onStart).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── プログレスインジケーター ──────────────────────────────────────────────
+
+  describe('プログレスインジケーター', () => {
+    it('ステップ 1 に進むとドット 0 と 1 が cyan になる', () => {
+      const { container } = renderOverlay();
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ }));
+      const dots = Array.from(container.querySelectorAll('.rounded-full.h-2.w-2'));
+      expect((dots[0] as HTMLElement).style.background).toContain('rgb(0, 229, 255)');
+      expect((dots[1] as HTMLElement).style.background).toContain('rgb(0, 229, 255)');
+    });
+
+    it('ステップ 1 のとき未到達ドット（2, 3）は暗い色', () => {
+      const { container } = renderOverlay();
+      fireEvent.click(screen.getByRole('button', { name: /次へ/ }));
+      const dots = Array.from(container.querySelectorAll('.rounded-full.h-2.w-2'));
+      expect((dots[2] as HTMLElement).style.background).not.toContain('rgb(0, 229, 255)');
+      expect((dots[3] as HTMLElement).style.background).not.toContain('rgb(0, 229, 255)');
+    });
+  });
+
+  // ─── オーバーレイ構造 ────────────────────────────────────────────────────
+
+  describe('オーバーレイ構造', () => {
+    it('オーバーレイが z-[200] クラスを持つ', () => {
+      const { container } = renderOverlay();
+      const overlay = container.querySelector('[class*="z-\\[200\\]"]');
+      expect(overlay).toBeTruthy();
+    });
+
+    it('本文テキストが表示される', () => {
+      renderOverlay();
+      expect(screen.getByText(/魔法陣をお手本通りになぞって/)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
- Add localStorage-based first-visit tutorial trigger in MagicCircleCanvas
- Save tutorialCompleted flag to localStorage on tutorial finish
- Add TutorialOverlay.test.tsx with 15 tests covering step transitions, progress indicator, and overlay structure
- Add 4 tutorial auto-display tests to MagicCircleCanvas.test.tsx

Fixes #77