### PR TITLE
feat: auto-play on history detail open, fix play button (issue #84)

### DIFF
--- a/src/components/HistoryDetail.test.tsx
+++ b/src/components/HistoryDetail.test.tsx
@@ -273,3 +273,59 @@ describe('HistoryDetail — ボタン・インタラクション', () => {
     expect(screen.getByRole('button', { name: /共有/ })).toBeInTheDocument();
   });
 });
+
+// ─── 自動再生テスト ────────────────────────────────────────────────────────────
+
+describe('HistoryDetail — 自動再生', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rafCallbacks.length = 0;
+    vi.useFakeTimers();
+    vi.stubGlobal('requestAnimationFrame', mockRaf);
+    vi.stubGlobal('cancelAnimationFrame', mockCancelRaf);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLCanvasElement.prototype as any).getContext = () => mockCtx;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLCanvasElement.prototype as any).getContext = () => null;
+  });
+
+  it('drawLogs があるとき history が開くと自動再生が始まる', () => {
+    renderDetail(makeHistory(2));
+    act(() => { vi.runAllTimers(); });
+    expect(screen.getByRole('button', { name: /⏸️ 一時停止/ })).toBeTruthy();
+  });
+
+  it('drawLogs が空のとき自動再生は起動しない', () => {
+    renderDetail(makeHistory(0));
+    act(() => { vi.runAllTimers(); });
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).toBeTruthy();
+  });
+
+  it('別の history に切り替えると再自動再生が起動する', () => {
+    const { rerender } = renderDetail(makeHistory(2, 'history-a'));
+    act(() => { vi.runAllTimers(); });
+    // 一時停止して確認
+    act(() => { fireEvent.click(screen.getByRole('button', { name: /⏸️ 一時停止/ })); });
+    expect(screen.getByRole('button', { name: /▶️ 再生/ })).toBeTruthy();
+
+    // 別履歴に切り替え
+    act(() => {
+      rerender(
+        <HistoryDetail
+          history={makeHistory(2, 'history-b')}
+          onClose={vi.fn()}
+          onReEdit={vi.fn()}
+        />
+      );
+    });
+    act(() => { vi.runAllTimers(); });
+
+    expect(screen.getByRole('button', { name: /⏸️ 一時停止/ })).toBeTruthy();
+  });
+});

--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -147,6 +147,17 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
     }
   }, [history]);
 
+  // Auto-play ref: always points to the latest handlePlay to avoid stale closure
+  const handlePlayRef = useRef<() => void>(() => {});
+
+  // Auto-play when a history item is opened
+  useEffect(() => {
+    if (!history?.data?.drawLogs?.length) return;
+    // setTimeout(0) defers until after the reset effect and re-render settle
+    const id = setTimeout(() => { handlePlayRef.current(); }, 0);
+    return () => clearTimeout(id);
+  }, [history]);
+
   const handlePlay = useCallback(() => {
     if (!history || !canvasRef.current) return;
 
@@ -261,6 +272,9 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
 
     replayAnimRef.current = requestAnimationFrame(animate);
   }, [history, currentTime, totalDuration, drawTemplate]);
+
+  // Keep ref in sync with latest handlePlay every render
+  handlePlayRef.current = handlePlay;
 
   const handlePause = useCallback(() => {
     if (replayAnimRef.current !== null) {


### PR DESCRIPTION
- Add auto-play: when a history item is opened, playback starts automatically via setTimeout(0) after reset effect settles
- Use handlePlayRef pattern to always call the latest handlePlay and avoid stale closure issues
- Add 3 auto-play tests to HistoryDetail.test.tsx using fake timers (total: 11 tests, all passing)

Fixes #84