### PR TITLE
feat: grimoire entry point and routing (T1 of #113)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,3 +65,13 @@ body {
 .btn-breathe {
   animation: glow-pulse 1.8s ease-in-out infinite;
 }
+
+/* 魔導書ページのフェードイン（控えめ・180ms） */
+@keyframes grimoire-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.grimoire-fade-in {
+  animation: grimoire-fade 180ms ease-out;
+}

--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+/**
+ * 魔導書ページ
+ * 魔法陣・アチーブメント・タイトル・チャレンジを集約するカード図鑑UI
+ * 現状はT1: エントリーポイントのみ。タブ・カードはT2以降で実装予定。
+ */
+export default function GrimoirePage() {
+  const router = useRouter();
+
+  return (
+    <div
+      className="grimoire-fade-in min-h-screen"
+      style={{ background: '#050505', color: '#e0e0ff' }}
+    >
+      {/* ヘッダー */}
+      <header
+        className="flex items-center justify-between px-4 py-3"
+        style={{ borderBottom: '1px solid rgba(0,229,255,0.15)' }}
+      >
+        <button
+          onClick={() => router.back()}
+          className="flex h-9 w-9 items-center justify-center rounded-full text-base transition-colors hover:bg-white/5"
+          style={{
+            border: '1px solid rgba(0,229,255,0.4)',
+            color: '#00e5ff',
+          }}
+          aria-label="戻る"
+        >
+          ←
+        </button>
+        <h1
+          className="text-base font-bold tracking-widest"
+          style={{ color: '#00e5ff' }}
+        >
+          魔導書
+        </h1>
+        <div className="h-9 w-9" />
+      </header>
+
+      {/* プレースホルダ：T2以降でタブ + カードグリッドを実装 */}
+      <main className="flex flex-col items-center justify-center px-4 py-12 text-center">
+        <p className="text-sm" style={{ color: '#7676aa' }}>
+          魔法陣・アチーブメント・タイトル・チャレンジ
+        </p>
+        <p className="mt-3 text-xs" style={{ color: '#4a4a6a' }}>
+          (T2以降のタスクで本実装)
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -135,6 +135,15 @@ export default function MagicCircleCanvas({
             className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
             style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
           >
+            {/* 魔導書 */}
+            <button
+              onClick={() => { router.push('/grimoire'); setShowMenu(false); }}
+              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+              style={{ color: '#00e5ff' }}
+            >
+              📖 魔導書
+            </button>
+
             {/* 作成履歴 */}
             <button
               onClick={() => { setShowHistory(true); setShowMenu(false); }}


### PR DESCRIPTION
## 概要

Closes #115 (Issue #113 のサブタスク T1)

魔導書機能のエントリーポイントとルーティングを実装しました。

## 変更内容

- `src/app/grimoire/page.tsx` 新規作成（ヘッダー + プレースホルダ）
- `src/app/globals.css` にフェードイン用の `.grimoire-fade-in` クラス追加（180ms）
- `MagicCircleCanvas.tsx` のメニューに「📖 魔導書」項目を追加

## 受け入れ条件

- [x] メニュー（≡）から「魔導書」を選択するとフェードで /grimoire に遷移する
- [x] 戻るボタンで元の画面に戻れる

## 補足

T2以降のタスク（タブ・カードグリッド・詳細）は #116〜#121 で順次実装予定です。