### PR TITLE
feat: grimoire magic circle card tab (T2 of #113)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,3 +75,24 @@ body {
 .grimoire-fade-in {
   animation: grimoire-fade 180ms ease-out;
 }
+
+/* 魔導書カード内の魔法陣プレビュー：ゆるやかな回転 */
+@keyframes grimoire-rotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.grimoire-rotate {
+  animation: grimoire-rotate 60s linear infinite;
+  transform-origin: 50% 50%;
+}
+
+/* 魔導書カードフレーム：1-2%の控えめパルス */
+@keyframes grimoire-frame-pulse {
+  0%, 100% { box-shadow: inset 0 0 0 1px rgba(0, 229, 255, 0); }
+  50% { box-shadow: inset 0 0 0 1px rgba(0, 229, 255, 0.18); }
+}
+
+.grimoire-card {
+  animation: grimoire-frame-pulse 4s ease-in-out infinite;
+}

--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -1,14 +1,41 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { createPresetPattern, type MagicCirclePattern } from '@/lib/patterns';
+import { getAllCompletions, type CompletionRecord } from '@/lib/completionDB';
+import MagicCircleCard from '@/components/grimoire/MagicCircleCard';
+
+const PATTERN_CANVAS_SIZE = 350;
+
+type TabId = 'circles' | 'achievements' | 'titles' | 'challenges';
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'circles', label: '魔法陣' },
+  { id: 'achievements', label: 'アチーブメント' },
+  { id: 'titles', label: 'タイトル' },
+  { id: 'challenges', label: 'チャレンジ' },
+];
 
 /**
  * 魔導書ページ
- * 魔法陣・アチーブメント・タイトル・チャレンジを集約するカード図鑑UI
- * 現状はT1: エントリーポイントのみ。タブ・カードはT2以降で実装予定。
+ * 4タブ構成（魔法陣 / アチーブメント / タイトル / チャレンジ）。
+ * 現状は魔法陣タブのみ実装（T2）。他タブはT3以降のサブタスクで本実装する。
  */
 export default function GrimoirePage() {
   const router = useRouter();
+  const [tab, setTab] = useState<TabId>('circles');
+  const [patterns, setPatterns] = useState<MagicCirclePattern[]>([]);
+  const [completions, setCompletions] = useState<CompletionRecord[]>([]);
+
+  useEffect(() => {
+    setPatterns(createPresetPattern(PATTERN_CANVAS_SIZE));
+    getAllCompletions()
+      .then(setCompletions)
+      .catch((e) => console.error('Failed to load completions:', e));
+  }, []);
+
+  const completionMap = new Map(completions.map((c) => [c.patternName, c]));
 
   return (
     <div
@@ -17,8 +44,11 @@ export default function GrimoirePage() {
     >
       {/* ヘッダー */}
       <header
-        className="flex items-center justify-between px-4 py-3"
-        style={{ borderBottom: '1px solid rgba(0,229,255,0.15)' }}
+        className="sticky top-0 z-10 flex items-center justify-between px-4 py-3"
+        style={{
+          background: '#050505',
+          borderBottom: '1px solid rgba(0,229,255,0.15)',
+        }}
       >
         <button
           onClick={() => router.back()}
@@ -40,15 +70,73 @@ export default function GrimoirePage() {
         <div className="h-9 w-9" />
       </header>
 
-      {/* プレースホルダ：T2以降でタブ + カードグリッドを実装 */}
-      <main className="flex flex-col items-center justify-center px-4 py-12 text-center">
-        <p className="text-sm" style={{ color: '#7676aa' }}>
-          魔法陣・アチーブメント・タイトル・チャレンジ
-        </p>
-        <p className="mt-3 text-xs" style={{ color: '#4a4a6a' }}>
-          (T2以降のタスクで本実装)
-        </p>
+      {/* タブ */}
+      <nav
+        className="flex"
+        style={{ borderBottom: '1px solid rgba(0,229,255,0.15)' }}
+      >
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className="flex-1 py-3 text-xs font-bold tracking-wider transition-colors"
+            style={{
+              color: tab === t.id ? '#00e5ff' : '#7676aa',
+              borderBottom:
+                tab === t.id
+                  ? '1px solid #00e5ff'
+                  : '1px solid transparent',
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      {/* コンテンツ */}
+      <main className="px-4 py-6">
+        {tab === 'circles' && (
+          <CircleGrid patterns={patterns} completionMap={completionMap} />
+        )}
+        {tab !== 'circles' && (
+          <p
+            className="text-center text-xs"
+            style={{ color: '#4a4a6a' }}
+          >
+            (T3以降のタスクで実装予定)
+          </p>
+        )}
       </main>
+    </div>
+  );
+}
+
+function CircleGrid({
+  patterns,
+  completionMap,
+}: {
+  patterns: MagicCirclePattern[];
+  completionMap: Map<string, CompletionRecord>;
+}) {
+  if (patterns.length === 0) {
+    return (
+      <p className="text-center text-xs" style={{ color: '#4a4a6a' }}>
+        読み込み中…
+      </p>
+    );
+  }
+  return (
+    <div
+      className="grid grid-flow-col grid-rows-2 gap-3 overflow-x-auto pb-2"
+      style={{ scrollSnapType: 'x mandatory' }}
+    >
+      {patterns.map((p) => (
+        <MagicCircleCard
+          key={p.name}
+          pattern={p}
+          completion={completionMap.get(p.name)}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/grimoire/MagicCircleCard.tsx
+++ b/src/components/grimoire/MagicCircleCard.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import type { MagicCirclePattern } from '@/lib/patterns';
+import type { CompletionRecord } from '@/lib/completionDB';
+
+const PATTERN_CANVAS_SIZE = 350;
+
+interface MagicCircleCardProps {
+  pattern: MagicCirclePattern;
+  completion?: CompletionRecord;
+}
+
+/**
+ * 魔導書 - 魔法陣カード（9:16縦長）
+ * 中央に魔法陣プレビュー（微回転）、下部にステータス（ベストランク・スコア・クリア回数）を表示する
+ */
+export default function MagicCircleCard({ pattern, completion }: MagicCircleCardProps) {
+  return (
+    <div
+      className="grimoire-card flex flex-col"
+      style={{
+        width: 144,
+        aspectRatio: '9 / 16',
+        background: '#0A0A0A',
+        border: '1px solid rgba(0, 229, 255, 0.4)',
+        borderRadius: 6,
+        flexShrink: 0,
+        scrollSnapAlign: 'start',
+        overflow: 'hidden',
+      }}
+    >
+      {/* プレビュー（微回転） */}
+      <div className="flex flex-1 items-center justify-center">
+        <svg
+          className="grimoire-rotate"
+          viewBox={`0 0 ${PATTERN_CANVAS_SIZE} ${PATTERN_CANVAS_SIZE}`}
+          width="80%"
+          height="80%"
+          aria-hidden
+        >
+          {pattern.circles.map((c, i) => (
+            <circle
+              key={`c-${i}`}
+              cx={c.cx * PATTERN_CANVAS_SIZE}
+              cy={c.cy * PATTERN_CANVAS_SIZE}
+              r={c.radius}
+              fill="none"
+              stroke="rgba(0, 229, 255, 0.45)"
+              strokeWidth={3}
+            />
+          ))}
+          {pattern.edges.map((e, i) => {
+            const a = pattern.vertices[e.from];
+            const b = pattern.vertices[e.to];
+            return (
+              <line
+                key={`e-${i}`}
+                x1={a.x}
+                y1={a.y}
+                x2={b.x}
+                y2={b.y}
+                stroke="rgba(0, 229, 255, 0.7)"
+                strokeWidth={3}
+              />
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* ステータス */}
+      <div
+        className="px-2 py-2 text-center"
+        style={{ borderTop: '1px solid rgba(0, 229, 255, 0.15)' }}
+      >
+        <div
+          className="truncate text-xs font-bold tracking-wider"
+          style={{ color: '#e0e0ff' }}
+        >
+          {pattern.name}
+        </div>
+        {completion ? (
+          <div className="mt-1 text-[10px] leading-tight" style={{ color: '#7676aa' }}>
+            <span style={{ color: getRankColor(completion.bestRank) }}>
+              {completion.bestRank}
+            </span>{' '}
+            {completion.bestScore}点
+            <div className="mt-0.5">✦ {completion.completionCount}回</div>
+          </div>
+        ) : (
+          <div className="mt-1 text-[10px]" style={{ color: '#4a4a6a' }}>
+            未挑戦
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getRankColor(rank: string): string {
+  switch (rank) {
+    case 'S':
+      return '#ffd700';
+    case 'A':
+      return '#00e5ff';
+    case 'B':
+      return '#76ff03';
+    default:
+      return '#ff4081';
+  }
+}

--- a/src/lib/completionDB.ts
+++ b/src/lib/completionDB.ts
@@ -11,7 +11,7 @@ const STORE_NAME = 'completion';
 /**
  * 完了記録のインターフェース
  */
-interface CompletionRecord {
+export interface CompletionRecord {
   /** パターン名 */
   patternName: string;
   /** 最高スコア */


### PR DESCRIPTION
## 概要

Closes #116 (Issue #113 サブタスク T2)

魔導書の「魔法陣」タブを実装しました。

## 変更内容

- `src/components/grimoire/MagicCircleCard.tsx` 新規作成（9:16カード + SVGプレビュー + ステータス）
- `src/app/grimoire/page.tsx` を更新：4タブレイアウト + 横スクロール2行グリッド
- `src/app/globals.css` にアニメーション追加：
  - `.grimoire-rotate`：プレビュー魔法陣の60秒1回転
  - `.grimoire-card`：4秒周期の控えめフレームパルス
- `src/lib/completionDB.ts` の `CompletionRecord` インターフェースを export 化

## 受け入れ条件

- [x] 4タブが表示・切替可能（魔法陣 / アチーブメント / タイトル / チャレンジ）
- [x] 9パターンのカードが2行に並び横スクロールできる
- [x] カードに保存済みのベストスコアが表示される（未挑戦は「未挑戦」と表示）
- [x] 魔法陣がカード内で微回転している
- [x] スクロールスナップが機能する

## 補足

T3〜T7（アチーブメント・タイトル・チャレンジ・詳細・仕上げ）は #117〜#121 で順次実装予定です。