### PR TITLE
feat: achievement definitions, persistence and tests (T3 of #113)

### DIFF
--- a/src/lib/achievementDB.ts
+++ b/src/lib/achievementDB.ts
@@ -1,0 +1,114 @@
+import { getAllHistories } from '@/lib/historyDB';
+import { getAllCompletions } from '@/lib/completionDB';
+import {
+  ACHIEVEMENTS,
+  evaluateAchievements,
+} from '@/lib/achievements';
+
+/** データベース名 */
+const DB_NAME = 'ArcaneTracerAchievement';
+/** データベースバージョン */
+const DB_VERSION = 1;
+/** オブジェクトストア名 */
+const STORE_NAME = 'achievement';
+
+/**
+ * アチーブメント解除レコード
+ */
+export interface AchievementUnlock {
+  /** アチーブメントID */
+  id: string;
+  /** 解除した日時（タイムスタンプ） */
+  unlockedAt: number;
+}
+
+/**
+ * IndexedDB接続を開く
+ */
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * 指定アチーブメントを解除済みとして記録（既に解除済みなら何もしない）
+ */
+export async function unlockAchievement(id: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const getReq = store.get(id);
+    getReq.onsuccess = () => {
+      if (getReq.result) {
+        resolve();
+        return;
+      }
+      const putReq = store.put({ id, unlockedAt: Date.now() } as AchievementUnlock);
+      putReq.onsuccess = () => resolve();
+      putReq.onerror = () => reject(putReq.error);
+    };
+    getReq.onerror = () => reject(getReq.error);
+  });
+}
+
+/**
+ * 全解除レコードを取得
+ */
+export async function getUnlockedAchievements(): Promise<AchievementUnlock[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () =>
+      resolve(request.result as AchievementUnlock[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * 解除済みアチーブメントのID集合を取得
+ */
+export async function getUnlockedAchievementIds(): Promise<Set<string>> {
+  const list = await getUnlockedAchievements();
+  return new Set(list.map((u) => u.id));
+}
+
+/**
+ * 指定IDが解除済みか
+ */
+export async function isAchievementUnlocked(id: string): Promise<boolean> {
+  const ids = await getUnlockedAchievementIds();
+  return ids.has(id);
+}
+
+/**
+ * 履歴・完了データから条件を再評価し、新たに解除されたものを保存する。
+ * 結果として新規解除されたアチーブメントID配列を返す。
+ */
+export async function checkAndUnlockAchievements(): Promise<string[]> {
+  const [histories, completions, unlockedIds] = await Promise.all([
+    getAllHistories(),
+    getAllCompletions(),
+    getUnlockedAchievementIds(),
+  ]);
+  const achieved = new Set(evaluateAchievements({ histories, completions }));
+  const newlyUnlocked: string[] = [];
+  for (const ach of ACHIEVEMENTS) {
+    if (!achieved.has(ach.id)) continue;
+    if (unlockedIds.has(ach.id)) continue;
+    await unlockAchievement(ach.id);
+    newlyUnlocked.push(ach.id);
+  }
+  return newlyUnlocked;
+}

--- a/src/lib/achievements.test.ts
+++ b/src/lib/achievements.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ACHIEVEMENTS,
+  evaluateAchievements,
+  getAchievementById,
+  type AchievementCheckData,
+} from './achievements';
+import type { MagicCircleHistory } from './types';
+import type { CompletionRecord } from './completionDB';
+
+function makeHistory(
+  overrides: Partial<MagicCircleHistory> = {},
+): MagicCircleHistory {
+  return {
+    id: `h_${Math.random().toString(36).slice(2, 9)}`,
+    data: {
+      pattern: { name: '三角形', vertices: [], edges: [], circles: [] },
+      drawLogs: [],
+      timestamp: Date.now(),
+    },
+    score: 80,
+    rank: 'B',
+    difficulty: 'NORMAL',
+    difficultyMultiplier: 1.0,
+    damageMultiplier: '1.0',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeCompletion(
+  overrides: Partial<CompletionRecord> = {},
+): CompletionRecord {
+  return {
+    patternName: '三角形',
+    bestScore: 80,
+    bestRank: 'B',
+    completedAt: 0,
+    completionCount: 0,
+    lastAttempted: Date.now(),
+    ...overrides,
+  };
+}
+
+const empty: AchievementCheckData = { histories: [], completions: [] };
+
+describe('ACHIEVEMENTS - 定義の整合性', () => {
+  it('IDがすべてユニーク', () => {
+    const ids = ACHIEVEMENTS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('10件以上定義されている', () => {
+    expect(ACHIEVEMENTS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('getAchievementById で取得できる', () => {
+    const ach = getAchievementById('first_step');
+    expect(ach).toBeDefined();
+    expect(ach?.name).toBe('最初の一筆');
+  });
+});
+
+describe('first_step（最初の一筆）', () => {
+  const ach = getAchievementById('first_step')!;
+  it('履歴ゼロでは未達成', () => {
+    expect(ach.check(empty)).toBe(false);
+  });
+  it('履歴1件で達成', () => {
+    expect(ach.check({ histories: [makeHistory()], completions: [] })).toBe(true);
+  });
+});
+
+describe('first_s（神の筆致）', () => {
+  const ach = getAchievementById('first_s')!;
+  it('Sランクが無ければ未達成', () => {
+    expect(
+      ach.check({ histories: [makeHistory({ rank: 'A' })], completions: [] }),
+    ).toBe(false);
+  });
+  it('Sランク履歴があれば達成', () => {
+    expect(
+      ach.check({
+        histories: [makeHistory({ rank: 'B' }), makeHistory({ rank: 'S' })],
+        completions: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('three_master（三冠魔導士）', () => {
+  const ach = getAchievementById('three_master')!;
+  it('Sが2件では未達成', () => {
+    const completions = [
+      makeCompletion({ patternName: '三角形', bestRank: 'S' }),
+      makeCompletion({ patternName: '五芒星', bestRank: 'S' }),
+    ];
+    expect(ach.check({ histories: [], completions })).toBe(false);
+  });
+  it('Sが3件で達成', () => {
+    const completions = [
+      makeCompletion({ patternName: '三角形', bestRank: 'S' }),
+      makeCompletion({ patternName: '五芒星', bestRank: 'S' }),
+      makeCompletion({ patternName: '六芒星', bestRank: 'S' }),
+    ];
+    expect(ach.check({ histories: [], completions })).toBe(true);
+  });
+});
+
+describe('all_master（全パターン制覇）', () => {
+  const ach = getAchievementById('all_master')!;
+  it('8件では未達成', () => {
+    const completions = Array.from({ length: 8 }, (_, i) =>
+      makeCompletion({ patternName: `pattern${i}`, bestRank: 'S' }),
+    );
+    expect(ach.check({ histories: [], completions })).toBe(false);
+  });
+  it('9件で達成', () => {
+    const completions = Array.from({ length: 9 }, (_, i) =>
+      makeCompletion({ patternName: `pattern${i}`, bestRank: 'S' }),
+    );
+    expect(ach.check({ histories: [], completions })).toBe(true);
+  });
+});
+
+describe('hard_breaker / expert_master', () => {
+  it('HARD履歴があれば hard_breaker 達成', () => {
+    expect(
+      getAchievementById('hard_breaker')!.check({
+        histories: [makeHistory({ difficulty: 'HARD' })],
+        completions: [],
+      }),
+    ).toBe(true);
+  });
+  it('EXPERT履歴があれば expert_master 達成', () => {
+    expect(
+      getAchievementById('expert_master')!.check({
+        histories: [makeHistory({ difficulty: 'EXPERT' })],
+        completions: [],
+      }),
+    ).toBe(true);
+  });
+  it('NORMALだけでは hard_breaker 未達成', () => {
+    expect(
+      getAchievementById('hard_breaker')!.check({
+        histories: [makeHistory({ difficulty: 'NORMAL' })],
+        completions: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('perfect_score（完璧なる詠唱）', () => {
+  const ach = getAchievementById('perfect_score')!;
+  it('99点では未達成', () => {
+    expect(
+      ach.check({ histories: [makeHistory({ score: 99 })], completions: [] }),
+    ).toBe(false);
+  });
+  it('100点で達成', () => {
+    expect(
+      ach.check({ histories: [makeHistory({ score: 100 })], completions: [] }),
+    ).toBe(true);
+  });
+});
+
+describe('streak_5（連続達成）', () => {
+  const ach = getAchievementById('streak_5')!;
+  it('履歴4件では未達成', () => {
+    const histories = Array.from({ length: 4 }, () =>
+      makeHistory({ rank: 'S' }),
+    );
+    expect(ach.check({ histories, completions: [] })).toBe(false);
+  });
+  it('直近5件すべてA以上で達成', () => {
+    const histories = [
+      makeHistory({ rank: 'S' }),
+      makeHistory({ rank: 'A' }),
+      makeHistory({ rank: 'S' }),
+      makeHistory({ rank: 'A' }),
+      makeHistory({ rank: 'S' }),
+      makeHistory({ rank: 'C' }), // 6件目（範囲外）
+    ];
+    expect(ach.check({ histories, completions: [] })).toBe(true);
+  });
+  it('先頭5件にBが混じれば未達成', () => {
+    const histories = [
+      makeHistory({ rank: 'S' }),
+      makeHistory({ rank: 'B' }),
+      makeHistory({ rank: 'A' }),
+      makeHistory({ rank: 'A' }),
+      makeHistory({ rank: 'S' }),
+    ];
+    expect(ach.check({ histories, completions: [] })).toBe(false);
+  });
+});
+
+describe('evaluateAchievements', () => {
+  it('空データではどれも達成しない', () => {
+    expect(evaluateAchievements(empty)).toEqual([]);
+  });
+  it('1件のSランク履歴で first_step と first_s が達成', () => {
+    const data: AchievementCheckData = {
+      histories: [makeHistory({ rank: 'S' })],
+      completions: [],
+    };
+    const ids = evaluateAchievements(data);
+    expect(ids).toContain('first_step');
+    expect(ids).toContain('first_s');
+    expect(ids).not.toContain('three_master');
+  });
+});

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -1,0 +1,140 @@
+import type { MagicCircleHistory } from '@/lib/types';
+import type { CompletionRecord } from '@/lib/completionDB';
+
+/**
+ * アチーブメント判定に必要なプレイヤーデータのスナップショット
+ */
+export interface AchievementCheckData {
+  /** プレイ履歴（新しい順） */
+  histories: MagicCircleHistory[];
+  /** パターン別の完了記録 */
+  completions: CompletionRecord[];
+}
+
+/**
+ * アチーブメント定義
+ */
+export interface Achievement {
+  /** 内部識別子（IndexedDBキー） */
+  id: string;
+  /** 表示名 */
+  name: string;
+  /** 達成条件の説明文 */
+  description: string;
+  /** アイコン（幾何記号 or 絵文字） */
+  icon: string;
+  /** 達成判定関数 */
+  check: (data: AchievementCheckData) => boolean;
+}
+
+/** Sランク達成数のしきい値 */
+const SRANK_TRIPLE = 3;
+const SRANK_ALL = 9;
+const PLAY_COUNT_PERSISTENT = 100;
+const HISTORY_COUNT_COLLECTOR = 20;
+const STREAK_LENGTH = 5;
+const PERFECT_SCORE = 100;
+
+/**
+ * アチーブメント一覧（10種）
+ * `check` は与えられたデータが達成条件を満たすかを判定する純粋関数。
+ */
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: 'first_step',
+    name: '最初の一筆',
+    description: '魔法陣を初めて完成させた',
+    icon: '◯',
+    check: ({ histories }) => histories.length >= 1,
+  },
+  {
+    id: 'first_s',
+    name: '神の筆致',
+    description: '初めてSランクを取得',
+    icon: '✦',
+    check: ({ histories }) => histories.some((h) => h.rank === 'S'),
+  },
+  {
+    id: 'three_master',
+    name: '三冠魔導士',
+    description: '3つのパターンでSランクを達成',
+    icon: '△',
+    check: ({ completions }) =>
+      completions.filter((c) => c.bestRank === 'S').length >= SRANK_TRIPLE,
+  },
+  {
+    id: 'all_master',
+    name: '全パターン制覇',
+    description: '9パターン全てでSランクを達成',
+    icon: '✧',
+    check: ({ completions }) =>
+      completions.filter((c) => c.bestRank === 'S').length >= SRANK_ALL,
+  },
+  {
+    id: 'persistent',
+    name: '魔導の探求者',
+    description: '累計100回プレイ',
+    icon: '◐',
+    check: ({ histories }) => histories.length >= PLAY_COUNT_PERSISTENT,
+  },
+  {
+    id: 'hard_breaker',
+    name: '困難への挑戦',
+    description: 'HARD難易度をクリア',
+    icon: '◇',
+    check: ({ histories }) =>
+      histories.some((h) => h.difficulty === 'HARD'),
+  },
+  {
+    id: 'expert_master',
+    name: '極致の魔導士',
+    description: 'EXPERT難易度をクリア',
+    icon: '◆',
+    check: ({ histories }) =>
+      histories.some((h) => h.difficulty === 'EXPERT'),
+  },
+  {
+    id: 'perfect_score',
+    name: '完璧なる詠唱',
+    description: '100点を取得',
+    icon: '★',
+    check: ({ histories }) =>
+      histories.some((h) => h.score >= PERFECT_SCORE),
+  },
+  {
+    id: 'collector',
+    name: '記録の蒐集者',
+    description: '履歴を20件以上保存',
+    icon: '▤',
+    check: ({ histories }) => histories.length >= HISTORY_COUNT_COLLECTOR,
+  },
+  {
+    id: 'streak_5',
+    name: '連続達成',
+    description: '直近5回連続でAランク以上',
+    icon: '▶',
+    check: ({ histories }) => {
+      if (histories.length < STREAK_LENGTH) return false;
+      // historyDB は新しい順で返るため先頭から STREAK_LENGTH 件を見る
+      return histories
+        .slice(0, STREAK_LENGTH)
+        .every((h) => h.rank === 'S' || h.rank === 'A');
+    },
+  },
+];
+
+/**
+ * IDから定義を取得
+ */
+export function getAchievementById(id: string): Achievement | undefined {
+  return ACHIEVEMENTS.find((a) => a.id === id);
+}
+
+/**
+ * 与えられたデータで達成済みのアチーブメントID一覧を返す（純粋関数）
+ */
+export function evaluateAchievements(
+  data: AchievementCheckData,
+): string[] {
+  return ACHIEVEMENTS.filter((a) => a.check(data)).map((a) => a.id);
+}


### PR DESCRIPTION
## 概要

Closes #117 (Issue #113 サブタスク T3)

魔導書のアチーブメント機能のデータ層・ロジック層・ユニットテストを実装しました。

## 変更内容

### 新規ファイル

- **`src/lib/achievements.ts`** — アチーブメント型定義・10種の定義・判定関数
  - `Achievement` インターフェース（id / name / description / icon / check）
  - `evaluateAchievements()`：与えられたデータから達成済みID配列を返す純粋関数
- **`src/lib/achievementDB.ts`** — IndexedDB永続化レイヤ
  - `unlockAchievement()` / `getUnlockedAchievements()` / `getUnlockedAchievementIds()` / `isAchievementUnlocked()`
  - `checkAndUnlockAchievements()`：履歴・完了データから条件再評価して新規解除分を保存
- **`src/lib/achievements.test.ts`** — ユニットテスト（21件、全Pass）

### 定義したアチーブメント10種

| ID | 名称 | 条件 |
|---|---|---|
| `first_step` | 最初の一筆 | 履歴1件以上 |
| `first_s` | 神の筆致 | Sランク取得 |
| `three_master` | 三冠魔導士 | 3パターンでS |
| `all_master` | 全パターン制覇 | 9パターンでS |
| `persistent` | 魔導の探求者 | 累計100回プレイ |
| `hard_breaker` | 困難への挑戦 | HARD履歴あり |
| `expert_master` | 極致の魔導士 | EXPERT履歴あり |
| `perfect_score` | 完璧なる詠唱 | 100点取得 |
| `collector` | 記録の蒐集者 | 履歴20件以上 |
| `streak_5` | 連続達成 | 直近5件すべてA以上 |

## 受け入れ条件

- [x] アチーブメントが達成可能・達成判定が動作する
- [x] ユニットテストでロジックを検証する（21テスト全Pass）

## 補足

UI連携（カード表示・解除アニメ）は T4 (#118) で実装予定です。