### PR TITLE
feat: achievement card UI with seal-break unlock (T4 of #113)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,3 +96,27 @@ body {
 .grimoire-card {
   animation: grimoire-frame-pulse 4s ease-in-out infinite;
 }
+
+/* アチーブメント未解除時のシール表現 */
+.grimoire-seal {
+  position: absolute;
+  inset: 0;
+  background-color: #050505;
+  background-image:
+    linear-gradient(45deg, transparent 47%, rgba(0,229,255,0.18) 49%, rgba(0,229,255,0.18) 51%, transparent 53%),
+    linear-gradient(-45deg, transparent 47%, rgba(0,229,255,0.12) 49%, rgba(0,229,255,0.12) 51%, transparent 53%);
+  background-size: 18px 18px;
+  pointer-events: none;
+}
+
+/* 解除アニメーション：青ライン強化 → ガラスが砕けるように消失 */
+@keyframes grimoire-seal-break {
+  0% { opacity: 1; transform: scale(1); filter: brightness(1); }
+  25% { opacity: 1; transform: scale(1.02); filter: brightness(1.6); }
+  55% { opacity: 0.65; transform: scale(1.06); filter: brightness(1.3); }
+  100% { opacity: 0; transform: scale(1.18); filter: brightness(0.6); }
+}
+
+.grimoire-seal-break {
+  animation: grimoire-seal-break 900ms ease-out forwards;
+}

--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -4,7 +4,13 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createPresetPattern, type MagicCirclePattern } from '@/lib/patterns';
 import { getAllCompletions, type CompletionRecord } from '@/lib/completionDB';
+import { ACHIEVEMENTS } from '@/lib/achievements';
+import {
+  checkAndUnlockAchievements,
+  getUnlockedAchievementIds,
+} from '@/lib/achievementDB';
 import MagicCircleCard from '@/components/grimoire/MagicCircleCard';
+import AchievementCard from '@/components/grimoire/AchievementCard';
 
 const PATTERN_CANVAS_SIZE = 350;
 
@@ -27,12 +33,22 @@ export default function GrimoirePage() {
   const [tab, setTab] = useState<TabId>('circles');
   const [patterns, setPatterns] = useState<MagicCirclePattern[]>([]);
   const [completions, setCompletions] = useState<CompletionRecord[]>([]);
+  const [unlockedIds, setUnlockedIds] = useState<Set<string>>(new Set());
+  const [justUnlockedIds, setJustUnlockedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setPatterns(createPresetPattern(PATTERN_CANVAS_SIZE));
     getAllCompletions()
       .then(setCompletions)
       .catch((e) => console.error('Failed to load completions:', e));
+    // 履歴・完了データから条件を再評価し新規解除分を保存
+    checkAndUnlockAchievements()
+      .then(async (newlyUnlocked) => {
+        setJustUnlockedIds(new Set(newlyUnlocked));
+        const all = await getUnlockedAchievementIds();
+        setUnlockedIds(all);
+      })
+      .catch((e) => console.error('Failed to check achievements:', e));
   }, []);
 
   const completionMap = new Map(completions.map((c) => [c.patternName, c]));
@@ -98,12 +114,18 @@ export default function GrimoirePage() {
         {tab === 'circles' && (
           <CircleGrid patterns={patterns} completionMap={completionMap} />
         )}
-        {tab !== 'circles' && (
+        {tab === 'achievements' && (
+          <AchievementGrid
+            unlockedIds={unlockedIds}
+            justUnlockedIds={justUnlockedIds}
+          />
+        )}
+        {(tab === 'titles' || tab === 'challenges') && (
           <p
             className="text-center text-xs"
             style={{ color: '#4a4a6a' }}
           >
-            (T3以降のタスクで実装予定)
+            (T5以降のタスクで実装予定)
           </p>
         )}
       </main>
@@ -135,6 +157,30 @@ function CircleGrid({
           key={p.name}
           pattern={p}
           completion={completionMap.get(p.name)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AchievementGrid({
+  unlockedIds,
+  justUnlockedIds,
+}: {
+  unlockedIds: Set<string>;
+  justUnlockedIds: Set<string>;
+}) {
+  return (
+    <div
+      className="grid grid-flow-col grid-rows-2 gap-3 overflow-x-auto pb-2"
+      style={{ scrollSnapType: 'x mandatory' }}
+    >
+      {ACHIEVEMENTS.map((a) => (
+        <AchievementCard
+          key={a.id}
+          achievement={a}
+          unlocked={unlockedIds.has(a.id)}
+          justUnlocked={justUnlockedIds.has(a.id)}
         />
       ))}
     </div>

--- a/src/components/grimoire/AchievementCard.tsx
+++ b/src/components/grimoire/AchievementCard.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { Achievement } from '@/lib/achievements';
+
+interface AchievementCardProps {
+  achievement: Achievement;
+  unlocked: boolean;
+  /** 直近のチェックで初めて解除されたか（解除アニメーションの再生用） */
+  justUnlocked?: boolean;
+}
+
+/**
+ * 魔導書 - アチーブメントカード（9:16縦長）
+ * 未解除時は「シール」で覆い、解除済みはアイコンと条件説明を表示する。
+ * `justUnlocked` が true の場合、シールが破れる解除アニメーションを再生する。
+ */
+export default function AchievementCard({
+  achievement,
+  unlocked,
+  justUnlocked,
+}: AchievementCardProps) {
+  return (
+    <div
+      className="grimoire-card relative flex flex-col"
+      style={{
+        width: 144,
+        aspectRatio: '9 / 16',
+        background: '#0A0A0A',
+        border: '1px solid rgba(0, 229, 255, 0.4)',
+        borderRadius: 6,
+        flexShrink: 0,
+        scrollSnapAlign: 'start',
+        overflow: 'hidden',
+      }}
+    >
+      {/* 解除済みコンテンツ */}
+      <div className="flex flex-1 items-center justify-center">
+        <span
+          className="text-5xl"
+          style={{
+            color: unlocked ? '#00e5ff' : '#1a1a2a',
+            textShadow: unlocked ? '0 0 8px rgba(0,229,255,0.4)' : 'none',
+          }}
+          aria-hidden
+        >
+          {achievement.icon}
+        </span>
+      </div>
+
+      <div
+        className="px-2 py-2 text-center"
+        style={{ borderTop: '1px solid rgba(0, 229, 255, 0.15)' }}
+      >
+        <div
+          className="truncate text-xs font-bold tracking-wider"
+          style={{ color: unlocked ? '#e0e0ff' : '#3a3a5a' }}
+        >
+          {unlocked ? achievement.name : '???'}
+        </div>
+        <div
+          className="mt-1 text-[10px] leading-tight"
+          style={{
+            color: unlocked ? '#7676aa' : '#2a2a4a',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {unlocked ? achievement.description : '未解除'}
+        </div>
+      </div>
+
+      {/* シール（未解除時、または解除アニメ中に上から被せる） */}
+      {(!unlocked || justUnlocked) && (
+        <div
+          className={`grimoire-seal ${justUnlocked ? 'grimoire-seal-break' : ''}`}
+          aria-hidden
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Closes #118 (Issue #113 サブタスク T4)

魔導書の「アチーブメント」タブUIを実装しました。

## 変更内容

- **新規**: `src/components/grimoire/AchievementCard.tsx` — アチーブメントカード（9:16）
  - 解除済み：幾何アイコン + 名称 + 説明（最大3行）
  - 未解除：シール（黒地に青い斜線パターン）で全面を覆い、名称は「???」
  - `justUnlocked=true` 時は解除アニメ（`grimoire-seal-break`）を再生
- **更新**: `src/app/grimoire/page.tsx`
  - マウント時に `checkAndUnlockAchievements()` を呼び新規解除を保存
  - 解除済みID集合と「直近で解除されたID集合」を別々に保持
  - アチーブメントタブに `AchievementGrid` を表示
- **追加CSS**: `globals.css`
  - `.grimoire-seal`：青い斜線2方向の半透明レイヤ
  - `.grimoire-seal-break`：900ms で「強発光 → 拡大 → フェードアウト」する解除アニメ

## 受け入れ条件

- [x] アチーブメントタブで全アチーブメントが表示される
- [x] 未解除はシール表現、解除済みはアイコン+説明表示
- [x] 解除直後に1度だけアンロックアニメーションが再生される（IndexedDB に保存し2回目以降は再生されない）

## 動作確認

プレビューで IndexedDB に2件直接挿入して再読み込みした結果：
- 解除済み2件：アイコン+名称+説明が表示
- 未解除8件：シール表示

## 補足

T5（タイトル・チャレンジ）は #119 で実装予定です。