### PR TITLE
feat: title and challenge cards for grimoire (T5 of #113)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,13 @@ body {
 .grimoire-seal-break {
   animation: grimoire-seal-break 900ms ease-out forwards;
 }
+
+/* チャレンジ達成時の発光エフェクト */
+@keyframes grimoire-challenge-glow {
+  0%, 100% { box-shadow: 0 0 6px rgba(0, 229, 255, 0.3), inset 0 0 6px rgba(0, 229, 255, 0.06); }
+  50% { box-shadow: 0 0 18px rgba(0, 229, 255, 0.6), inset 0 0 12px rgba(0, 229, 255, 0.12); }
+}
+
+.grimoire-challenge-complete {
+  animation: grimoire-challenge-glow 2.5s ease-in-out infinite;
+}

--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -1,16 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createPresetPattern, type MagicCirclePattern } from '@/lib/patterns';
 import { getAllCompletions, type CompletionRecord } from '@/lib/completionDB';
+import { getAllHistories } from '@/lib/historyDB';
+import type { MagicCircleHistory } from '@/lib/types';
 import { ACHIEVEMENTS } from '@/lib/achievements';
 import {
   checkAndUnlockAchievements,
   getUnlockedAchievementIds,
 } from '@/lib/achievementDB';
+import { TITLES, getEquippedTitleId, saveEquippedTitleId } from '@/lib/titles';
+import { CHALLENGES } from '@/lib/challenges';
 import MagicCircleCard from '@/components/grimoire/MagicCircleCard';
 import AchievementCard from '@/components/grimoire/AchievementCard';
+import TitleCard from '@/components/grimoire/TitleCard';
+import ChallengeCard from '@/components/grimoire/ChallengeCard';
 
 const PATTERN_CANVAS_SIZE = 350;
 
@@ -23,25 +29,25 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 'challenges', label: 'チャレンジ' },
 ];
 
-/**
- * 魔導書ページ
- * 4タブ構成（魔法陣 / アチーブメント / タイトル / チャレンジ）。
- * 現状は魔法陣タブのみ実装（T2）。他タブはT3以降のサブタスクで本実装する。
- */
 export default function GrimoirePage() {
   const router = useRouter();
   const [tab, setTab] = useState<TabId>('circles');
   const [patterns, setPatterns] = useState<MagicCirclePattern[]>([]);
   const [completions, setCompletions] = useState<CompletionRecord[]>([]);
+  const [histories, setHistories] = useState<MagicCircleHistory[]>([]);
   const [unlockedIds, setUnlockedIds] = useState<Set<string>>(new Set());
   const [justUnlockedIds, setJustUnlockedIds] = useState<Set<string>>(new Set());
+  const [equippedTitleId, setEquippedTitleId] = useState<string | null>(null);
 
   useEffect(() => {
     setPatterns(createPresetPattern(PATTERN_CANVAS_SIZE));
+    setEquippedTitleId(getEquippedTitleId());
     getAllCompletions()
       .then(setCompletions)
       .catch((e) => console.error('Failed to load completions:', e));
-    // 履歴・完了データから条件を再評価し新規解除分を保存
+    getAllHistories()
+      .then(setHistories)
+      .catch((e) => console.error('Failed to load histories:', e));
     checkAndUnlockAchievements()
       .then(async (newlyUnlocked) => {
         setJustUnlockedIds(new Set(newlyUnlocked));
@@ -51,6 +57,11 @@ export default function GrimoirePage() {
       .catch((e) => console.error('Failed to check achievements:', e));
   }, []);
 
+  const handleEquip = useCallback((id: string | null) => {
+    saveEquippedTitleId(id);
+    setEquippedTitleId(id);
+  }, []);
+
   const completionMap = new Map(completions.map((c) => [c.patternName, c]));
 
   return (
@@ -58,7 +69,6 @@ export default function GrimoirePage() {
       className="grimoire-fade-in min-h-screen"
       style={{ background: '#050505', color: '#e0e0ff' }}
     >
-      {/* ヘッダー */}
       <header
         className="sticky top-0 z-10 flex items-center justify-between px-4 py-3"
         style={{
@@ -86,7 +96,6 @@ export default function GrimoirePage() {
         <div className="h-9 w-9" />
       </header>
 
-      {/* タブ */}
       <nav
         className="flex"
         style={{ borderBottom: '1px solid rgba(0,229,255,0.15)' }}
@@ -109,7 +118,6 @@ export default function GrimoirePage() {
         ))}
       </nav>
 
-      {/* コンテンツ */}
       <main className="px-4 py-6">
         {tab === 'circles' && (
           <CircleGrid patterns={patterns} completionMap={completionMap} />
@@ -120,13 +128,15 @@ export default function GrimoirePage() {
             justUnlockedIds={justUnlockedIds}
           />
         )}
-        {(tab === 'titles' || tab === 'challenges') && (
-          <p
-            className="text-center text-xs"
-            style={{ color: '#4a4a6a' }}
-          >
-            (T5以降のタスクで実装予定)
-          </p>
+        {tab === 'titles' && (
+          <TitleGrid
+            unlockedIds={unlockedIds}
+            equippedTitleId={equippedTitleId}
+            onEquip={handleEquip}
+          />
+        )}
+        {tab === 'challenges' && (
+          <ChallengeGrid histories={histories} completions={completions} />
         )}
       </main>
     </div>
@@ -181,6 +191,56 @@ function AchievementGrid({
           achievement={a}
           unlocked={unlockedIds.has(a.id)}
           justUnlocked={justUnlockedIds.has(a.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TitleGrid({
+  unlockedIds,
+  equippedTitleId,
+  onEquip,
+}: {
+  unlockedIds: Set<string>;
+  equippedTitleId: string | null;
+  onEquip: (id: string | null) => void;
+}) {
+  return (
+    <div
+      className="grid grid-flow-col grid-rows-2 gap-3 overflow-x-auto pb-2"
+      style={{ scrollSnapType: 'x mandatory' }}
+    >
+      {TITLES.map((t) => (
+        <TitleCard
+          key={t.id}
+          title={t}
+          unlocked={unlockedIds.has(t.achievementId)}
+          equipped={equippedTitleId === t.id}
+          onEquip={onEquip}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ChallengeGrid({
+  histories,
+  completions,
+}: {
+  histories: MagicCircleHistory[];
+  completions: CompletionRecord[];
+}) {
+  return (
+    <div
+      className="grid grid-flow-col grid-rows-2 gap-3 overflow-x-auto pb-2"
+      style={{ scrollSnapType: 'x mandatory' }}
+    >
+      {CHALLENGES.map((c) => (
+        <ChallengeCard
+          key={c.id}
+          challenge={c}
+          progress={c.getProgress({ histories, completions })}
         />
       ))}
     </div>

--- a/src/components/grimoire/ChallengeCard.tsx
+++ b/src/components/grimoire/ChallengeCard.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { Challenge } from '@/lib/challenges';
+
+interface ChallengeCardProps {
+  challenge: Challenge;
+  progress: number;
+}
+
+export default function ChallengeCard({
+  challenge,
+  progress,
+}: ChallengeCardProps) {
+  const completed = progress >= challenge.target;
+  const pct = Math.min(100, Math.round((progress / challenge.target) * 100));
+
+  return (
+    <div
+      className={`grimoire-card relative flex flex-col ${completed ? 'grimoire-challenge-complete' : ''}`}
+      style={{
+        width: 144,
+        aspectRatio: '9 / 16',
+        background: '#0A0A0A',
+        border: `1px solid ${completed ? 'rgba(0,229,255,0.8)' : 'rgba(0,229,255,0.4)'}`,
+        borderRadius: 6,
+        flexShrink: 0,
+        scrollSnapAlign: 'start',
+        overflow: 'hidden',
+      }}
+    >
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-3">
+        <div
+          className="text-center text-xs font-bold tracking-wider"
+          style={{ color: completed ? '#00e5ff' : '#e0e0ff' }}
+        >
+          {challenge.title}
+        </div>
+        <div
+          className="text-center text-[10px] leading-tight"
+          style={{ color: '#7676aa' }}
+        >
+          {challenge.description}
+        </div>
+      </div>
+
+      <div
+        className="flex flex-col gap-2 px-3 py-3"
+        style={{ borderTop: '1px solid rgba(0, 229, 255, 0.15)' }}
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-[10px]" style={{ color: '#7676aa' }}>
+            {progress} / {challenge.target}
+          </span>
+          <span
+            className="text-[10px] font-bold"
+            style={{ color: completed ? '#00e5ff' : '#4a4a6a' }}
+          >
+            {completed ? '達成' : `${pct}%`}
+          </span>
+        </div>
+        <div
+          style={{
+            height: 4,
+            background: '#1a1a2a',
+            borderRadius: 2,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${pct}%`,
+              background: completed
+                ? 'linear-gradient(90deg, #00e5ff, #80f0ff)'
+                : 'linear-gradient(90deg, #00b4cc, #00e5ff)',
+              borderRadius: 2,
+              transition: 'width 0.3s ease',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/grimoire/TitleCard.tsx
+++ b/src/components/grimoire/TitleCard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import type { Title } from '@/lib/titles';
+
+interface TitleCardProps {
+  title: Title;
+  unlocked: boolean;
+  equipped: boolean;
+  onEquip: (id: string | null) => void;
+}
+
+export default function TitleCard({
+  title,
+  unlocked,
+  equipped,
+  onEquip,
+}: TitleCardProps) {
+  return (
+    <div
+      className="grimoire-card relative flex flex-col"
+      style={{
+        width: 144,
+        aspectRatio: '9 / 16',
+        background: '#0A0A0A',
+        border: `1px solid ${equipped ? 'rgba(0,229,255,0.8)' : 'rgba(0,229,255,0.4)'}`,
+        borderRadius: 6,
+        flexShrink: 0,
+        scrollSnapAlign: 'start',
+        overflow: 'hidden',
+        boxShadow: equipped ? '0 0 12px rgba(0,229,255,0.3)' : 'none',
+      }}
+    >
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 px-2">
+        <span
+          className="text-5xl"
+          style={{
+            color: unlocked ? '#00e5ff' : '#1a1a2a',
+            textShadow: unlocked ? '0 0 8px rgba(0,229,255,0.4)' : 'none',
+          }}
+          aria-hidden
+        >
+          {title.emblem}
+        </span>
+        <div
+          className="text-center text-xs font-bold tracking-wider"
+          style={{ color: unlocked ? '#e0e0ff' : '#3a3a5a' }}
+        >
+          {unlocked ? title.name : '???'}
+        </div>
+      </div>
+
+      <div
+        className="flex flex-col gap-2 px-2 py-2"
+        style={{ borderTop: '1px solid rgba(0, 229, 255, 0.15)' }}
+      >
+        <div
+          className="text-center text-[10px] leading-tight"
+          style={{ color: unlocked ? '#7676aa' : '#2a2a4a' }}
+        >
+          {unlocked ? title.condition : '未解除'}
+        </div>
+        {unlocked && (
+          <button
+            onClick={() => onEquip(equipped ? null : title.id)}
+            className="w-full py-1 text-[10px] font-bold tracking-wider transition-colors"
+            style={{
+              background: equipped
+                ? 'rgba(0,229,255,0.2)'
+                : 'rgba(0,229,255,0.08)',
+              border: '1px solid rgba(0,229,255,0.4)',
+              borderRadius: 3,
+              color: '#00e5ff',
+            }}
+          >
+            {equipped ? '装備中' : '装備する'}
+          </button>
+        )}
+      </div>
+
+      {!unlocked && (
+        <div className="grimoire-seal" aria-hidden />
+      )}
+    </div>
+  );
+}

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -1,0 +1,83 @@
+import type { MagicCircleHistory } from '@/lib/types';
+import type { CompletionRecord } from '@/lib/completionDB';
+
+export interface ChallengeCheckData {
+  histories: MagicCircleHistory[];
+  completions: CompletionRecord[];
+}
+
+export interface Challenge {
+  id: string;
+  title: string;
+  description: string;
+  target: number;
+  getProgress: (data: ChallengeCheckData) => number;
+}
+
+export const CHALLENGES: Challenge[] = [
+  {
+    id: 'play_1',
+    title: '初めての試み',
+    description: '1回プレイする',
+    target: 1,
+    getProgress: ({ histories }) => Math.min(histories.length, 1),
+  },
+  {
+    id: 'play_10',
+    title: '基礎の習得',
+    description: '10回プレイする',
+    target: 10,
+    getProgress: ({ histories }) => Math.min(histories.length, 10),
+  },
+  {
+    id: 'play_50',
+    title: '精進の道',
+    description: '50回プレイする',
+    target: 50,
+    getProgress: ({ histories }) => Math.min(histories.length, 50),
+  },
+  {
+    id: 's_rank_3',
+    title: 'Sランクへの挑戦',
+    description: 'Sランクを3回取得する',
+    target: 3,
+    getProgress: ({ histories }) =>
+      Math.min(histories.filter((h) => h.rank === 'S').length, 3),
+  },
+  {
+    id: 'all_patterns',
+    title: '全パターン挑戦',
+    description: '全9種のパターンをプレイする',
+    target: 9,
+    getProgress: ({ completions }) => Math.min(completions.length, 9),
+  },
+  {
+    id: 'hard_5',
+    title: '高難度の試練',
+    description: 'HARD以上の難易度を5回クリアする',
+    target: 5,
+    getProgress: ({ histories }) =>
+      Math.min(
+        histories.filter(
+          (h) => h.difficulty === 'HARD' || h.difficulty === 'EXPERT',
+        ).length,
+        5,
+      ),
+  },
+  {
+    id: 'perfect_3',
+    title: '完璧への執着',
+    description: '100点を3回取得する',
+    target: 3,
+    getProgress: ({ histories }) =>
+      Math.min(histories.filter((h) => h.score >= 100).length, 3),
+  },
+  {
+    id: 'expert_1',
+    title: '極限への挑戦',
+    description: 'EXPERT難易度をクリアする',
+    target: 1,
+    getProgress: ({ histories }) =>
+      histories.some((h) => h.difficulty === 'EXPERT') ? 1 : 0,
+  },
+];

--- a/src/lib/titles.ts
+++ b/src/lib/titles.ts
@@ -1,0 +1,102 @@
+export interface Title {
+  id: string;
+  name: string;
+  emblem: string;
+  condition: string;
+  achievementId: string;
+}
+
+export const TITLES: Title[] = [
+  {
+    id: 'novice',
+    name: '見習い魔導士',
+    emblem: '◯',
+    condition: '最初の魔法陣を完成させる',
+    achievementId: 'first_step',
+  },
+  {
+    id: 'flash_mage',
+    name: '閃光の魔導士',
+    emblem: '✦',
+    condition: '初めてSランクを取得',
+    achievementId: 'first_s',
+  },
+  {
+    id: 'triple_master',
+    name: '三冠魔導士',
+    emblem: '△',
+    condition: '3種のパターンでSランク達成',
+    achievementId: 'three_master',
+  },
+  {
+    id: 'conqueror',
+    name: '全パターン制覇者',
+    emblem: '✧',
+    condition: '全パターンでSランク達成',
+    achievementId: 'all_master',
+  },
+  {
+    id: 'seeker',
+    name: '魔導の探求者',
+    emblem: '◐',
+    condition: '累計100回プレイ',
+    achievementId: 'persistent',
+  },
+  {
+    id: 'hard_conqueror',
+    name: '困難の克服者',
+    emblem: '◇',
+    condition: 'HARD難易度をクリア',
+    achievementId: 'hard_breaker',
+  },
+  {
+    id: 'expert_sage',
+    name: '極致の賢者',
+    emblem: '◆',
+    condition: 'EXPERT難易度をクリア',
+    achievementId: 'expert_master',
+  },
+  {
+    id: 'perfect_chanter',
+    name: '完璧詠唱者',
+    emblem: '★',
+    condition: '100点を取得',
+    achievementId: 'perfect_score',
+  },
+  {
+    id: 'archivist',
+    name: '記録の蒐集者',
+    emblem: '▤',
+    condition: '履歴を20件保存',
+    achievementId: 'collector',
+  },
+  {
+    id: 'streak_master',
+    name: '連続達成の覇者',
+    emblem: '▶',
+    condition: '5連続でAランク以上',
+    achievementId: 'streak_5',
+  },
+];
+
+const EQUIPPED_KEY = 'arcane_tracer_equipped_title';
+
+export function getEquippedTitleId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return localStorage.getItem(EQUIPPED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function saveEquippedTitleId(id: string | null): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (id === null) {
+      localStorage.removeItem(EQUIPPED_KEY);
+    } else {
+      localStorage.setItem(EQUIPPED_KEY, id);
+    }
+  } catch {}
+}


### PR DESCRIPTION
## 概要

魔導書のタイトル・チャレンジタブを実装します（Issue #119 / T5）。

- `src/lib/titles.ts` — 10種のタイトル定義（アチーブメントIDと紐付け、localStorage装備保存）
- `src/lib/challenges.ts` — 8種のチャレンジ定義（純粋関数で進捗計算）
- `TitleCard.tsx` — シールオーバーレイ・装備ボタン・装備中バッジ付きカード
- `ChallengeCard.tsx` — プログレスバー・達成時発光エフェクト付きカード
- `globals.css` — `.grimoire-challenge-complete` 発光アニメーション追加
- `grimoire/page.tsx` — タイトル/チャレンジタブにカードグリッドを描画、履歴もロード

Fixes #119

## テスト

- TypeScript型エラーなし（`tsc --noEmit` パス）
- ブラウザプレビューで全4タブの表示を確認
  - タイトルタブ：未解除カードがシール表示
  - チャレンジタブ：ミッション名・説明・プログレスバー（0/N・0%）表示
  - コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)