### PR TITLE
feat: navigate to game with selected pattern from grimoire

### DIFF
--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -64,6 +64,10 @@ export default function GrimoirePage() {
     setEquippedTitleId(id);
   }, []);
 
+  const handleDraw = useCallback((patternName: string) => {
+    router.push(`/?pattern=${encodeURIComponent(patternName)}`);
+  }, [router]);
+
   const completionMap = new Map(completions.map((c) => [c.patternName, c]));
 
   return (
@@ -156,6 +160,7 @@ export default function GrimoirePage() {
           onClose={() => setSelectedCard(null)}
           onEquip={handleEquip}
           equippedTitleId={equippedTitleId}
+          onDraw={handleDraw}
         />
       )}
     </div>

--- a/src/components/grimoire/CardDetailModal.tsx
+++ b/src/components/grimoire/CardDetailModal.tsx
@@ -19,6 +19,7 @@ interface CardDetailModalProps {
   onClose: () => void;
   onEquip?: (id: string | null) => void;
   equippedTitleId?: string | null;
+  onDraw?: (patternName: string) => void;
 }
 
 export default function CardDetailModal({
@@ -26,6 +27,7 @@ export default function CardDetailModal({
   onClose,
   onEquip,
   equippedTitleId,
+  onDraw,
 }: CardDetailModalProps) {
   return (
     <div
@@ -81,7 +83,7 @@ export default function CardDetailModal({
         </button>
 
         <div style={{ position: 'relative' }}>
-          {card.type === 'circle' && <CircleDetail card={card} />}
+          {card.type === 'circle' && <CircleDetail card={card} onDraw={onDraw} />}
           {card.type === 'achievement' && <AchievementDetail card={card} />}
           {card.type === 'title' && (
             <TitleDetail
@@ -134,8 +136,10 @@ function ModalBackground() {
 
 function CircleDetail({
   card,
+  onDraw,
 }: {
   card: Extract<SelectedCard, { type: 'circle' }>;
+  onDraw?: (patternName: string) => void;
 }) {
   const { pattern, completion } = card;
   return (
@@ -201,6 +205,28 @@ function CircleDetail({
         </div>
       ) : (
         <p style={{ textAlign: 'center', color: '#4a4a6a', fontSize: 12 }}>未挑戦</p>
+      )}
+
+      {onDraw && (
+        <div style={{ marginTop: 16, display: 'flex', justifyContent: 'center' }}>
+          <button
+            onClick={() => onDraw(pattern.name)}
+            style={{
+              padding: '9px 28px',
+              background: 'rgba(0,229,255,0.12)',
+              border: '1px solid rgba(0,229,255,0.6)',
+              borderRadius: 6,
+              color: '#00e5ff',
+              fontSize: 12,
+              fontWeight: 'bold',
+              letterSpacing: '0.05em',
+              cursor: 'pointer',
+              touchAction: 'manipulation',
+            }}
+          >
+            このパターンで描く
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## 概要

魔導書の魔法陣カード詳細から、選択したパターンで描けるようにページ遷移する機能を追加します。

## 変更内容

- `CardDetailModal.tsx` — 魔法陣詳細に「このパターンで描く」ボタンを追加
  - `onDraw?: (patternName: string) => void` プロップを新設
- `grimoire/page.tsx` — `handleDraw` コールバックを追加
  - `router.push('/?pattern=' + encodeURIComponent(patternName))` で遷移

メインページ (`src/app/page.tsx`) は既に `?pattern=<名前>` クエリパラメータをサポート済みのため、追加の変更は不要です。

Fixes #128

## テスト

- 魔導書 → 魔法陣カードをタップ → 詳細モーダルに「このパターンで描く」ボタンが表示される
- ボタンをタップ → `/?pattern=%E4%B8%89%E8%A7%92%E5%BD%A2`（例: 三角形）に遷移
- メイン画面でそのパターンが選択済み状態で表示される
- コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)