### PR TITLE
fix: Issue #141 品質問題の修正（メモリリーク/デバッグログ/型/アクセシビリティ/無限ループ）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,7 @@ function HomeContent() {
         <div className="mt-4 text-center">
           <div className="text-lg" style={{ color: '#7c4dff' }}>
             前回の結果: <span className="font-bold">{lastResult.rank}</span>{' '}
-            (スコア: {lastResult.score}, 倍率: {lastResult.difficultyMultiplier ?? 1}x, {lastResult.damageMultiplier}ダメージ)
+            (スコア: {lastResult.score}, 倍率: {lastResult.difficultyMultiplier}x, {lastResult.damageMultiplier}ダメージ)
           </div>
         </div>
       )}

--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -208,50 +208,23 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
   }, [history]);
 
   const handlePlay = useCallback(() => {
-    console.log('[HistoryDetail] handlePlay called');
-    if (!history || !canvasRef.current) {
-      console.log('[HistoryDetail] Early return: history or canvas missing');
-      return;
-    }
+    if (!history || !canvasRef.current) return;
 
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      console.log('[HistoryDetail] Early return: canvas context missing');
-      return;
-    }
+    if (!ctx) return;
 
-    if (!history.data) {
-      console.log('[HistoryDetail] Early return: history.data missing');
-      return;
-    }
-    if (!history.data.drawLogs) {
-      console.log('[HistoryDetail] Early return: drawLogs missing');
-      return;
-    }
+    if (!history.data) return;
+    if (!history.data.drawLogs) return;
 
-    console.log('[HistoryDetail] drawLogs length:', history.data.drawLogs.length);
-    console.log('[HistoryDetail] drawLogs structure:', history.data.drawLogs);
     const drawLogs = history.data.drawLogs;
     const normalizedLogs = createReplayDrawLogs(drawLogs);
-    console.log('[HistoryDetail] normalizedLogs length:', normalizedLogs.length);
-    console.log('[HistoryDetail] normalizedLogs structure:', normalizedLogs);
-    normalizedLogs.forEach((stroke, idx) => {
-      console.log(`[HistoryDetail] stroke[${idx}] length:`, stroke.length, 'content:', stroke);
-    });
     const STROKE_INTERVAL_MS = 500;
     const allEvents: DrawEvent[] = [];
     let timeOffset = 0;
-    for (let i = 0; i < normalizedLogs.length; i++) {
-      const stroke = normalizedLogs[i];
-      console.log(`[HistoryDetail] Processing stroke ${i}, length: ${stroke.length}`);
-      if (stroke.length === 0) {
-        console.log(`[HistoryDetail] Stroke ${i} is empty, skipping`);
-        continue;
-      }
-      console.log(`[HistoryDetail] Stroke ${i} has ${stroke.length} events`);
+    for (const stroke of normalizedLogs) {
+      if (stroke.length === 0) continue;
       for (const ev of stroke) {
-        console.log(`[HistoryDetail] Adding event: x=${ev.x}, y=${ev.y}, t=${ev.t}`);
         allEvents.push({ x: ev.x, y: ev.y, t: ev.t + timeOffset, type: ev.type });
       }
       if (allEvents.length > 0) {
@@ -259,11 +232,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       }
     }
 
-    console.log('[HistoryDetail] allEvents length:', allEvents.length);
-    if (allEvents.length === 0) {
-      console.log('[HistoryDetail] Early return: no events to replay');
-      return;
-    }
+    if (allEvents.length === 0) return;
     const totalDuration = allEvents[allEvents.length - 1].t;
     setTotalDuration(totalDuration);
 

--- a/src/components/MagicCircleCanvas.test.tsx
+++ b/src/components/MagicCircleCanvas.test.tsx
@@ -5,6 +5,13 @@ import type { UseMagicCircleReturn } from '@/hooks/useMagicCircle';
 // useMagicCircle フックをモック
 vi.mock('@/hooks/useMagicCircle');
 
+// next/navigation をモック（useRouter はコンポーネント内で直接呼び出される）
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/',
+}));
+
 // 子コンポーネントをモック（テスト対象外）
 vi.mock('./HelpModal', () => ({ default: () => null }));
 vi.mock('./HistoryPanel', () => ({ default: () => null }));
@@ -122,7 +129,7 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
     it('showResult=true のとき disabled', () => {
       renderCanvas({
         showResult: true,
-        scoreResult: { score: 80, rank: 'A', damageMultiplier: '150%' },
+        scoreResult: { score: 80, rank: 'A', damageMultiplier: '150%', difficultyMultiplier: 1 },
       });
       expect(screen.getByRole('button', { name: '詠唱完了！' })).toBeDisabled();
     });
@@ -136,7 +143,7 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
   // ─── リプレイボタン（結果画面） ───────────────────────────────────────────
 
   describe('リプレイボタン（結果画面）', () => {
-    const scoreResult = { score: 90, rank: 'S', damageMultiplier: '200%' };
+    const scoreResult = { score: 90, rank: 'S', damageMultiplier: '200%', difficultyMultiplier: 1 };
 
     it('drawLogs あり かつ isReplaying=false のとき enabled', () => {
       renderCanvas({
@@ -185,7 +192,7 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
     it('showResult=true のとき scoreResult のランクが表示される', () => {
       renderCanvas({
         showResult: true,
-        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%' },
+        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%', difficultyMultiplier: 1 },
       });
       expect(screen.getByText('A')).toBeInTheDocument();
     });
@@ -193,7 +200,7 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
     it('showResult=true のとき scoreResult のスコアが表示される', () => {
       renderCanvas({
         showResult: true,
-        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%' },
+        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%', difficultyMultiplier: 1 },
       });
       expect(screen.getByText('85点')).toBeInTheDocument();
     });
@@ -201,7 +208,7 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
     it('showResult=true のとき damageMultiplier が表示される', () => {
       renderCanvas({
         showResult: true,
-        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%' },
+        scoreResult: { score: 85, rank: 'A', damageMultiplier: '100%', difficultyMultiplier: 1 },
       });
       expect(screen.getByText(/100%/)).toBeInTheDocument();
     });

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -240,6 +240,7 @@ export default function MagicCircleCanvas({
           <button
             onClick={handlePrevious}
             disabled={currentIndex === 0}
+            aria-label="前のパターン"
             className="flex h-8 w-8 items-center justify-center rounded-md border border-gray-600 bg-gray-800/50 text-gray-400 hover:bg-gray-600/70 transition-colors disabled:opacity-50"
           >
             〈
@@ -253,6 +254,7 @@ export default function MagicCircleCanvas({
           <button
             onClick={handleNext}
             disabled={currentIndex >= totalPatterns - 1}
+            aria-label="次のパターン"
             className="flex h-8 w-8 items-center justify-center rounded-md border border-gray-600 bg-gray-800/50 text-gray-400 hover:bg-gray-600/70 transition-colors disabled:opacity-50"
           >
             〉
@@ -382,6 +384,7 @@ export default function MagicCircleCanvas({
         <button
           onClick={handleEvaluate}
           disabled={showResult || isReplaying}
+          aria-label="詠唱完了してスコアを判定する"
           className={`cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-80${(isDrawing || drawLogs.length > 0) && !showResult && !isReplaying ? ' btn-breathe' : ''}`}
           style={{ background: 'linear-gradient(135deg, #00e5ff, #7c4dff)' }}
         >
@@ -389,6 +392,7 @@ export default function MagicCircleCanvas({
         </button>
         <button
           onClick={handleReset}
+          aria-label="描画をリセットする"
           className="cursor-pointer rounded-md border-2 border-gray-600 px-6 py-2 font-bold transition-colors hover:bg-gray-800"
         >
           リセット

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -173,15 +173,22 @@ export function useMagicCircle(
   // handleEvaluateはこの位置より後で定義されるため、refで前方参照する
   const handleEvaluateRef = useRef<(() => void) | null>(null);
 
-  // 音声検知フックを初期化（コンポーネントレベルで呼び出し）
-  const voiceHook = useVoiceActivation(async () => {
-    // 音声が検知されたときのコールバック
-    // 評価ボタンを自動的に押す（ただし、アクティブで結果が表示されていない場合のみ）
+  // onCompletionUpdateはレンダリング毎に新しい参照になるためrefで保持（ループ防止）
+  const onCompletionUpdateRef = useRef(onCompletionUpdate);
+  onCompletionUpdateRef.current = onCompletionUpdate;
+
+  // 音声検知コールバックをrefで保持（安定した参照を提供してレンダリングループを防止）
+  const onVoiceDetectedRef = useRef<() => void>(() => {});
+  onVoiceDetectedRef.current = () => {
     if (isActive && !showResult && userPath.length >= 10) {
       handleEvaluateRef.current?.();
       setDebugMsg('🔊 音声検知により自動評価を実行しました');
     }
-  }, {
+  };
+  const stableOnVoiceDetected = useCallback(() => onVoiceDetectedRef.current(), []);
+
+  // 音声検知フックを初期化（コンポーネントレベルで呼び出し）
+  const voiceHook = useVoiceActivation(stableOnVoiceDetected, {
     threshold: 0.15, // やや高めの閾値に設定（環境ノイズ対策）
     silentTime: 800, // 0.8秒無音で音声終了と判定
     checkInterval: 100
@@ -234,7 +241,7 @@ export function useMagicCircle(
     }
   }, [initialPatternName]);
 
-  // Update completion status when patterns change
+  // マウント時に完了状況を読み込み（refを使用してループを防止）
   useEffect(() => {
     let isMounted = true;
     async function loadCompletionStatus() {
@@ -246,28 +253,18 @@ export function useMagicCircle(
         if (isMounted) {
           const status = { completed: completedCount, total: totalCount };
           setCompletionStatus(status);
-          // 親コンポーネントに完了状況を通知
-          if (onCompletionUpdate) {
-            onCompletionUpdate(status);
-          }
+          onCompletionUpdateRef.current?.(status);
         }
       } catch (e) {
         console.error('Failed to load completion status:', e);
-        if (isMounted && onCompletionUpdate) {
-          onCompletionUpdate(null);
+        if (isMounted) {
+          onCompletionUpdateRef.current?.(null);
         }
       }
     }
     loadCompletionStatus();
     return () => { isMounted = false; };
-  }, [onCompletionUpdate]);
-
-  // 完了状況の変更を親に通知する別のエフェクト
-  useEffect(() => {
-    if (onCompletionUpdate) {
-      onCompletionUpdate(completionStatus);
-    }
-  }, [completionStatus, onCompletionUpdate]);
+  }, []);
 
   const currentPattern = patterns[currentIdx];
   /** 残り時間（実際のタイマー値） */
@@ -418,7 +415,6 @@ export function useMagicCircle(
     if (!canvas) return;
 
     const handlePointerDown = (e: PointerEvent) => {
-      console.log('[useMagicCircle-native] pointerdown triggered');
       e.preventDefault();
       canvas.setPointerCapture(e.pointerId);
       startDrawing(getCanvasPos(e.clientX, e.clientY));
@@ -426,7 +422,6 @@ export function useMagicCircle(
 
     const handlePointerMove = (e: PointerEvent) => {
       if (isDrawingRef.current) {
-        console.log('[useMagicCircle-native] pointermove triggered');
         e.preventDefault();
         draw(getCanvasPos(e.clientX, e.clientY));
       }
@@ -434,20 +429,17 @@ export function useMagicCircle(
 
     const handlePointerUp = (e: PointerEvent) => {
       if (isDrawingRef.current) {
-        console.log('[useMagicCircle-native] pointerup triggered');
         e.preventDefault();
         // pointerleave の二重発火を防ぐため ref を先に false にする
         isDrawingRef.current = false;
         setIsDrawing(false);
         const elapsed = performance.now() - strokeStartTimeRef.current;
         const lastPoint = drawLogRef.current[drawLogRef.current.length - 1];
-        drawLogRef.current.push({ x: lastPoint.x, y: lastPoint.y, t: elapsed, type: 'end' });
-        console.log('[useMagicCircle-native] strokeToSave length:', drawLogRef.current.length);
+        if (lastPoint) {
+          drawLogRef.current.push({ x: lastPoint.x, y: lastPoint.y, t: elapsed, type: 'end' });
+        }
         const strokeToSave = [...drawLogRef.current];
-        setDrawLogs((prev) => {
-          console.log('[useMagicCircle-native] setDrawLogs callback, adding stroke with', strokeToSave.length, 'events');
-          return [...prev, strokeToSave];
-        });
+        setDrawLogs((prev) => [...prev, strokeToSave]);
         drawLogRef.current = [];
         setUserPath([]);
         setDebugMsg('描画完了。スコア判定しますか？');
@@ -573,7 +565,6 @@ export function useMagicCircle(
   }, [showResult, drawLogs, currentPattern, drawTemplate]);
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
-    console.log('[useMagicCircle] onPointerDown triggered');
     e.stopPropagation();
     if (canvasRef.current) {
       canvasRef.current.setPointerCapture(e.pointerId);
@@ -834,7 +825,7 @@ export function useMagicCircle(
       score: result.score,
       rank: result.rank,
       difficulty: DIFFICULTY_LABELS[difficulty],
-      difficultyMultiplier: result.difficultyMultiplier ?? 1,
+      difficultyMultiplier: result.difficultyMultiplier,
       damageMultiplier: result.damageMultiplier,
       thumbnail,
       createdAt: Date.now(),

--- a/src/hooks/useVoiceActivation.ts
+++ b/src/hooks/useVoiceActivation.ts
@@ -31,6 +31,7 @@ export function useVoiceActivation(
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const microphoneRef = useRef<MediaStream | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const isListeningRef = useRef<boolean>(false);
   const lastVoiceTimeRef = useRef<number>(0);
@@ -92,13 +93,11 @@ export function useVoiceActivation(
     }
 
     try {
-      // マイク入力をアナライザーに接続（まだ接続していない場合）
-      if (audioContextRef.current && microphoneRef.current) {
-        const source = audioContextRef.current.createMediaStreamSource(microphoneRef.current);
-        source.connect(analyserRef.current);
-      } else {
-        console.warn('AudioContext or microphone not available');
-        return;
+      // マイク入力をアナライザーに接続（初回のみ）
+      if (!sourceRef.current) {
+        if (!audioContextRef.current || !microphoneRef.current) return;
+        sourceRef.current = audioContextRef.current.createMediaStreamSource(microphoneRef.current);
+        sourceRef.current.connect(analyserRef.current);
       }
 
       // 周波数データを取得
@@ -180,6 +179,12 @@ export function useVoiceActivation(
         console.error('AudioContext閉じるエラー:', err);
       }
       audioContextRef.current = null;
+    }
+
+    // ソースノードを切断してクリア
+    if (sourceRef.current) {
+      sourceRef.current.disconnect();
+      sourceRef.current = null;
     }
 
     // アナライザーをクリア

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -10,8 +10,8 @@ export interface ScoringResult {
   rank: string;
   /** ダメージ倍率 (例: '120%') */
   damageMultiplier: string;
-  /** 難易度倍率 (オプション) */
-  difficultyMultiplier?: number;
+  /** 難易度倍率 */
+  difficultyMultiplier: number;
 }
 
 /**
@@ -114,7 +114,7 @@ export function calculateScore(
 ): ScoringResult {
   // 最低限の描画点数チェック
   if (userPath.length < 10) {
-    return { score: 0, rank: 'C', damageMultiplier: '0%' };
+    return { score: 0, rank: 'C', damageMultiplier: '0%', difficultyMultiplier: 1 };
   }
 
   // テンプレート点と頂点、周長を取得
@@ -176,5 +176,5 @@ export function calculateScore(
     damageMultiplier = '0%';
   }
 
-  return { score: roundedScore, rank, damageMultiplier };
+  return { score: roundedScore, rank, damageMultiplier, difficultyMultiplier: 1 };
 }


### PR DESCRIPTION
## 概要

Issue #141 で報告された HIGH/MEDIUM 優先度の品質問題をすべて修正します。

## 修正内容

### HIGH
- **AudioContextメモリリーク修正** (`useVoiceActivation.ts`): `checkAudioLevel` が毎フレーム `createMediaStreamSource` を呼び出していた問題を修正。`sourceRef` でノードを管理し、初回のみ生成するよう変更。`stopListening` でも確実にソースノードを `disconnect()` するよう対応。

### MEDIUM
- **デバッグconsole.log削除** (`useMagicCircle.ts` 6箇所、`HistoryDetail.tsx` 16箇所): 本番コードに残留していた開発用ログをすべて削除。
- **lastPointのnullチェック追加** (`useMagicCircle.ts`): `drawLogRef.current` が空配列のとき `lastPoint` が `undefined` になるクラッシュを防止。
- **aria-label追加** (`MagicCircleCanvas.tsx`): 前へ（〈）・次へ（〉）・詠唱完了！・リセットの各ボタンにアクセシビリティ用テキストを付与。
- **`ScoringResult.difficultyMultiplier` を必須フィールドに変更** (`scoring.ts`): `?` をなくし、すべての `return` に `difficultyMultiplier: 1` を明示。

### 無限レンダーループ修正（CRITICAL）
PR #140 の変更により発生した「Maximum update depth exceeded」の無限ループを修正:
- **`onCompletionUpdate` ループ**: 冗長な第2 `useEffect`（L265-270）を削除。`onCompletionUpdateRef` を使用して、親コールバックの参照変化によるループを防止。
- **voiceHook ループ**: `useVoiceActivation` に渡すコールバックをインライン Arrow Function から `useCallback` + refパターン（`stableOnVoiceDetected`）に変更。これにより `checkAudioLevel` → `startListening` の参照が毎レンダー変化しなくなる。

### テスト修正
- `MagicCircleCanvas.test.tsx` に `next/navigation` の `useRouter` モックを追加（`MagicCircleCanvas` が直接 `useRouter` を使用するため）
- `scoreResult` フィクスチャに `difficultyMultiplier: 1` を追加（必須フィールド化に対応）

## テスト結果

- TypeScript: ✅ エラーなし
- ESLint: ✅ 警告なし
- `src/components/MagicCircleCanvas.test.tsx`: ✅ 23/23 通過
- `src/lib/scoring.test.ts`: ✅ 27/27 通過
- プロダクションビルド: ✅ 成功

Fixes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)