### PR TITLE
fix: LOW優先度の品質問題4件を修正

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,49 +12,61 @@
       "src": "/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ],
   "screenshots": [

--- a/src/app/grimoire/page.test.tsx
+++ b/src/app/grimoire/page.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Next.js ルーターをモック
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+// データベース関数をモック
+vi.mock('@/lib/completionDB', () => ({
+  getAllCompletions: vi.fn(),
+}));
+vi.mock('@/lib/historyDB', () => ({
+  getAllHistories: vi.fn(),
+}));
+vi.mock('@/lib/achievementDB', () => ({
+  checkAndUnlockAchievements: vi.fn(),
+  getUnlockedAchievementIds: vi.fn(),
+}));
+vi.mock('@/lib/titles', () => ({
+  TITLES: [],
+  getEquippedTitleId: () => null,
+  saveEquippedTitleId: vi.fn(),
+}));
+vi.mock('@/lib/challenges', () => ({
+  CHALLENGES: [],
+}));
+vi.mock('@/lib/achievements', () => ({
+  ACHIEVEMENTS: [],
+}));
+vi.mock('@/lib/patterns', () => ({
+  createPresetPattern: () => [],
+}));
+
+// サブコンポーネントをモック
+vi.mock('@/components/grimoire/MagicCircleCard', () => ({ default: () => null }));
+vi.mock('@/components/grimoire/AchievementCard', () => ({ default: () => null }));
+vi.mock('@/components/grimoire/TitleCard', () => ({ default: () => null }));
+vi.mock('@/components/grimoire/ChallengeCard', () => ({ default: () => null }));
+vi.mock('@/components/grimoire/CardDetailModal', () => ({ default: () => null }));
+
+import { getAllCompletions } from '@/lib/completionDB';
+import { getAllHistories } from '@/lib/historyDB';
+import { checkAndUnlockAchievements, getUnlockedAchievementIds } from '@/lib/achievementDB';
+import GrimoirePage from './page';
+
+const mockGetAllCompletions = vi.mocked(getAllCompletions);
+const mockGetAllHistories = vi.mocked(getAllHistories);
+const mockCheckAndUnlockAchievements = vi.mocked(checkAndUnlockAchievements);
+const mockGetUnlockedAchievementIds = vi.mocked(getUnlockedAchievementIds);
+
+function setupSuccessMocks() {
+  mockGetAllCompletions.mockResolvedValue([]);
+  mockGetAllHistories.mockResolvedValue([]);
+  mockCheckAndUnlockAchievements.mockResolvedValue([]);
+  mockGetUnlockedAchievementIds.mockResolvedValue(new Set());
+}
+
+describe('GrimoirePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── 正常系 ──────────────────────────────────────────────────────────────────
+
+  describe('正常系', () => {
+    it('ページタイトル「魔導書」が表示される', () => {
+      setupSuccessMocks();
+      render(<GrimoirePage />);
+      expect(screen.getByText('魔導書')).toBeTruthy();
+    });
+
+    it('4つのタブ（魔法陣・アチーブメント・タイトル・チャレンジ）が表示される', () => {
+      setupSuccessMocks();
+      render(<GrimoirePage />);
+      expect(screen.getByText('魔法陣')).toBeTruthy();
+      expect(screen.getByText('アチーブメント')).toBeTruthy();
+      expect(screen.getByText('タイトル')).toBeTruthy();
+      expect(screen.getByText('チャレンジ')).toBeTruthy();
+    });
+
+    it('データ読み込み成功時にエラーバナーは表示されない', async () => {
+      setupSuccessMocks();
+      render(<GrimoirePage />);
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).toBeNull();
+      });
+    });
+  });
+
+  // ─── エラーハンドリング ───────────────────────────────────────────────────────
+
+  describe('エラーハンドリング', () => {
+    it('getAllCompletions が失敗するとエラーバナーが表示される', async () => {
+      mockGetAllCompletions.mockRejectedValue(new Error('DB error'));
+      mockGetAllHistories.mockResolvedValue([]);
+      mockCheckAndUnlockAchievements.mockResolvedValue([]);
+      mockGetUnlockedAchievementIds.mockResolvedValue(new Set());
+
+      render(<GrimoirePage />);
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeTruthy();
+      });
+      expect(screen.getByText(/魔法陣データの読み込みに失敗しました/)).toBeTruthy();
+    });
+
+    it('getAllHistories が失敗するとエラーバナーが表示される', async () => {
+      mockGetAllCompletions.mockResolvedValue([]);
+      mockGetAllHistories.mockRejectedValue(new Error('DB error'));
+      mockCheckAndUnlockAchievements.mockResolvedValue([]);
+      mockGetUnlockedAchievementIds.mockResolvedValue(new Set());
+
+      render(<GrimoirePage />);
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeTruthy();
+      });
+      expect(screen.getByText(/履歴データの読み込みに失敗しました/)).toBeTruthy();
+    });
+
+    it('checkAndUnlockAchievements が失敗するとエラーバナーが表示される', async () => {
+      mockGetAllCompletions.mockResolvedValue([]);
+      mockGetAllHistories.mockResolvedValue([]);
+      mockCheckAndUnlockAchievements.mockRejectedValue(new Error('DB error'));
+      mockGetUnlockedAchievementIds.mockResolvedValue(new Set());
+
+      render(<GrimoirePage />);
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeTruthy();
+      });
+      expect(screen.getByText(/アチーブメントデータの読み込みに失敗しました/)).toBeTruthy();
+    });
+
+    it('エラーバナーの閉じるボタンでバナーが消える', async () => {
+      mockGetAllCompletions.mockRejectedValue(new Error('DB error'));
+      mockGetAllHistories.mockResolvedValue([]);
+      mockCheckAndUnlockAchievements.mockResolvedValue([]);
+      mockGetUnlockedAchievementIds.mockResolvedValue(new Set());
+
+      render(<GrimoirePage />);
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'エラーを閉じる' }));
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+  });
+});

--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -40,21 +40,31 @@ export default function GrimoirePage() {
   const [justUnlockedIds, setJustUnlockedIds] = useState<Set<string>>(new Set());
   const [equippedTitleId, setEquippedTitleId] = useState<string | null>(() => getEquippedTitleId());
   const [selectedCard, setSelectedCard] = useState<SelectedCard | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     getAllCompletions()
       .then(setCompletions)
-      .catch((e) => console.error('Failed to load completions:', e));
+      .catch((e) => {
+        console.error('Failed to load completions:', e);
+        setLoadError('魔法陣データの読み込みに失敗しました');
+      });
     getAllHistories()
       .then(setHistories)
-      .catch((e) => console.error('Failed to load histories:', e));
+      .catch((e) => {
+        console.error('Failed to load histories:', e);
+        setLoadError('履歴データの読み込みに失敗しました');
+      });
     checkAndUnlockAchievements()
       .then(async (newlyUnlocked) => {
         setJustUnlockedIds(new Set(newlyUnlocked));
         const all = await getUnlockedAchievementIds();
         setUnlockedIds(all);
       })
-      .catch((e) => console.error('Failed to check achievements:', e));
+      .catch((e) => {
+        console.error('Failed to check achievements:', e);
+        setLoadError('アチーブメントデータの読み込みに失敗しました');
+      });
   }, []);
 
   const handleEquip = useCallback((id: string | null) => {
@@ -119,6 +129,27 @@ export default function GrimoirePage() {
           </button>
         ))}
       </nav>
+
+      {loadError && (
+        <div
+          role="alert"
+          className="mx-4 mt-4 flex items-center justify-between rounded-lg px-4 py-3 text-sm"
+          style={{
+            background: 'rgba(255, 64, 129, 0.15)',
+            border: '1px solid rgba(255, 64, 129, 0.5)',
+            color: '#ff4081',
+          }}
+        >
+          <span>⚠️ {loadError}</span>
+          <button
+            onClick={() => setLoadError(null)}
+            aria-label="エラーを閉じる"
+            className="ml-3 text-base leading-none hover:opacity-70"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       <main className="px-4 py-6">
         {tab === 'circles' && (

--- a/src/components/HelpModal.test.tsx
+++ b/src/components/HelpModal.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import HelpModal from './HelpModal';
+
+describe('HelpModal', () => {
+  let onClose: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onClose = vi.fn();
+  });
+
+  // ─── 表示内容 ───────────────────────────────────────────────────────────────
+
+  describe('表示内容', () => {
+    it('ヘルプタイトルが表示される', () => {
+      render(<HelpModal onClose={onClose} />);
+      expect(screen.getByText(/ヘルプ/)).toBeTruthy();
+    });
+
+    it('5つの手順が番号付きで表示される', () => {
+      render(<HelpModal onClose={onClose} />);
+      for (let i = 1; i <= 5; i++) {
+        expect(screen.getByText(String(i))).toBeTruthy();
+      }
+    });
+
+    it('ランク一覧（S/A/B/C）が表示される', () => {
+      render(<HelpModal onClose={onClose} />);
+      expect(screen.getByText(/Sランク/)).toBeTruthy();
+      expect(screen.getByText(/Aランク/)).toBeTruthy();
+      expect(screen.getByText(/Bランク/)).toBeTruthy();
+      expect(screen.getByText(/Cランク/)).toBeTruthy();
+    });
+
+    it('「閉じる」ボタンが表示される', () => {
+      render(<HelpModal onClose={onClose} />);
+      expect(screen.getByRole('button', { name: '閉じる' })).toBeTruthy();
+    });
+  });
+
+  // ─── インタラクション ───────────────────────────────────────────────────────
+
+  describe('インタラクション', () => {
+    it('「閉じる」ボタンクリックで onClose が呼ばれる', () => {
+      render(<HelpModal onClose={onClose} />);
+      fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('オーバーレイ（背景）クリックで onClose が呼ばれる', () => {
+      const { container } = render(<HelpModal onClose={onClose} />);
+      const overlay = container.firstElementChild as HTMLElement;
+      fireEvent.click(overlay);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('モーダル内コンテンツのクリックでは onClose が呼ばれない', () => {
+      render(<HelpModal onClose={onClose} />);
+      // テキスト要素をクリックしてもオーバーレイに伝播しない
+      fireEvent.click(screen.getByText(/ヘルプ/));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -514,14 +514,16 @@ export function useMagicCircle(
 
       drawTemplate(currentPattern);
 
-      const pts: { x: number; y: number }[] = [];
-      for (const ev of allEvents) {
-        if (ev.t <= elapsed) {
-          pts.push({ x: ev.x, y: ev.y });
-        }
+      // 二分探索で elapsed 以前のイベント数を O(log n) で取得
+      let lo = 0, hi = allEvents.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (allEvents[mid].t <= elapsed) lo = mid + 1;
+        else hi = mid;
       }
+      const cutoff = lo;
 
-      if (pts.length > 1) {
+      if (cutoff > 1) {
         ctx.shadowBlur = 2;
         ctx.shadowColor = '#00e5ff';
         ctx.strokeStyle = '#00e5ff';
@@ -529,14 +531,14 @@ export function useMagicCircle(
         ctx.lineCap = 'round';
         ctx.lineJoin = 'round';
         ctx.beginPath();
-        ctx.moveTo(pts[0].x, pts[0].y);
-        for (let i = 1; i < pts.length; i++) {
-          ctx.lineTo(pts[i].x, pts[i].y);
+        ctx.moveTo(allEvents[0].x, allEvents[0].y);
+        for (let i = 1; i < cutoff; i++) {
+          ctx.lineTo(allEvents[i].x, allEvents[i].y);
         }
         ctx.stroke();
         ctx.shadowBlur = 0;
 
-        const last = pts[pts.length - 1];
+        const last = allEvents[cutoff - 1];
         ctx.shadowBlur = 2;
         ctx.shadowColor = '#00e5ff';
         ctx.fillStyle = '#ffffff';


### PR DESCRIPTION
## 概要

Issue #143 で報告されたLOW優先度の品質問題4件を修正します。

## 変更内容

### Fix #6 — リプレイアニメーション パフォーマンス最適化
- `useMagicCircle.ts` のリプレイアニメーションループで、毎フレームO(n)の線形スキャンを行っていた処理をO(log n)の二分探索に変更
- 長いストロークのリプレイで顕著なフレームレート改善が見込める

### Fix #7 — PWAマニフェスト `purpose` 記法修正
- `public/manifest.json` の非推奨な `"purpose": "any maskable"` スペース区切り記法を廃止
- W3C仕様に準拠した独立エントリ形式（`"purpose": "any"` と `"purpose": "maskable"` を別々に記述）に変更
- 192x192 と 512x512 サイズに `maskable` エントリを追加

### Fix #8 — grimoireページ エラーUI追加
- `src/app/grimoire/page.tsx` でDBエラー発生時に何も表示されなかった問題を修正
- 3つのDB操作（completions / histories / achievements）それぞれにエラーキャッチを追加
- 却下可能なエラーバナー（role="alert"）を表示するよう実装

### Fix #9 — テストカバレッジ追加
- `src/components/HelpModal.test.tsx` を新規追加（7テスト）
  - 表示内容（タイトル・手順番号・ランク表示・ボタン）
  - インタラクション（閉じるボタン・オーバーレイクリック・バブリング防止）
- `src/app/grimoire/page.test.tsx` を新規追加（7テスト）
  - 正常系（ページタイトル・タブ表示・エラーなし）
  - エラーハンドリング（各DBエラー時のバナー・閉じるボタン）

## テスト結果

新規追加テスト: **14件すべてパス**

```
✓ HelpModal > 表示内容 > ヘルプタイトルが表示される
✓ HelpModal > 表示内容 > 5つの手順が番号付きで表示される
✓ HelpModal > 表示内容 > ランク一覧（S/A/B/C）が表示される
✓ HelpModal > 表示内容 > 「閉じる」ボタンが表示される
✓ HelpModal > インタラクション > 「閉じる」ボタンクリックで onClose が呼ばれる
✓ HelpModal > インタラクション > オーバーレイ（背景）クリックで onClose が呼ばれる
✓ HelpModal > インタラクション > モーダル内コンテンツのクリックでは onClose が呼ばれない
✓ GrimoirePage > 正常系 > ページタイトル「魔導書」が表示される
✓ GrimoirePage > 正常系 > 4つのタブが表示される
✓ GrimoirePage > 正常系 > データ読み込み成功時にエラーバナーは表示されない
✓ GrimoirePage > エラーハンドリング > getAllCompletions が失敗するとエラーバナーが表示される
✓ GrimoirePage > エラーハンドリング > getAllHistories が失敗するとエラーバナーが表示される
✓ GrimoirePage > エラーハンドリング > checkAndUnlockAchievements が失敗するとエラーバナーが表示される
✓ GrimoirePage > エラーハンドリング > エラーバナーの閉じるボタンでバナーが消える
```

## 関連Issue

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)