### PR TITLE
fix: テスト失敗とコード品質問題を修正

### DIFF
--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -519,10 +519,16 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
               />
 
               {/* 中央の再生/停止オーバーレイ */}
-              <div
+              <button
                 className="absolute inset-0 flex items-center justify-center cursor-pointer rounded-lg"
                 onClick={() => isPlaying ? handlePause() : handlePlay()}
-                style={{ background: isPlaying ? 'transparent' : 'rgba(0,0,0,0.15)' }}
+                aria-label={isPlaying ? '⏹️ 停止' : '▶️ 再生'}
+                disabled={!history.data?.drawLogs?.length}
+                style={{
+                  background: isPlaying ? 'transparent' : 'rgba(0,0,0,0.15)',
+                  border: 'none',
+                  padding: 0,
+                }}
               >
                 {!isPlaying && !!history.data?.drawLogs?.length && (
                   <div
@@ -545,11 +551,12 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
                     }} />
                   </div>
                 )}
-              </div>
+              </button>
 
               {/* 共有ボタン（右上オーバーレイ） */}
               <button
                 onClick={handleShare}
+                aria-label="共有"
                 className="absolute top-2 right-2 flex items-center justify-center rounded-full text-sm transition-opacity hover:opacity-80"
                 style={{
                   width: 32,
@@ -558,7 +565,6 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
                   border: '1px solid rgba(0,229,255,0.4)',
                   color: '#00e5ff',
                 }}
-                title="共有"
               >
                 📤
               </button>

--- a/src/components/MagicCircleCanvas.test.tsx
+++ b/src/components/MagicCircleCanvas.test.tsx
@@ -90,12 +90,12 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
   describe('前へ（〈）ボタン', () => {
     it('currentIndex=0 のとき disabled', () => {
       renderCanvas({ currentIndex: 0 });
-      expect(screen.getByRole('button', { name: '〈' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: '前のパターン' })).toBeDisabled();
     });
 
     it('currentIndex=1 のとき enabled', () => {
       renderCanvas({ currentIndex: 1 });
-      expect(screen.getByRole('button', { name: '〈' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: '前のパターン' })).not.toBeDisabled();
     });
   });
 
@@ -104,17 +104,17 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
   describe('次へ（〉）ボタン', () => {
     it('currentIndex が totalPatterns-1 のとき disabled', () => {
       renderCanvas({ currentIndex: 2, totalPatterns: 3 });
-      expect(screen.getByRole('button', { name: '〉' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: '次のパターン' })).toBeDisabled();
     });
 
     it('currentIndex が totalPatterns-1 未満のとき enabled', () => {
       renderCanvas({ currentIndex: 1, totalPatterns: 3 });
-      expect(screen.getByRole('button', { name: '〉' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: '次のパターン' })).not.toBeDisabled();
     });
 
     it('totalPatterns=1 かつ currentIndex=0 のとき disabled', () => {
       renderCanvas({ currentIndex: 0, totalPatterns: 1 });
-      expect(screen.getByRole('button', { name: '〉' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: '次のパターン' })).toBeDisabled();
     });
   });
 
@@ -123,7 +123,7 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
   describe('詠唱完了！ボタン', () => {
     it('showResult=false かつ isReplaying=false のとき enabled', () => {
       renderCanvas({ showResult: false, isReplaying: false });
-      expect(screen.getByRole('button', { name: '詠唱完了！' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: '詠唱完了してスコアを判定する' })).not.toBeDisabled();
     });
 
     it('showResult=true のとき disabled', () => {
@@ -131,12 +131,12 @@ describe('MagicCircleCanvas — ボタン disabled 条件', () => {
         showResult: true,
         scoreResult: { score: 80, rank: 'A', damageMultiplier: '150%', difficultyMultiplier: 1 },
       });
-      expect(screen.getByRole('button', { name: '詠唱完了！' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: '詠唱完了してスコアを判定する' })).toBeDisabled();
     });
 
     it('isReplaying=true のとき disabled', () => {
       renderCanvas({ isReplaying: true });
-      expect(screen.getByRole('button', { name: '詠唱完了！' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: '詠唱完了してスコアを判定する' })).toBeDisabled();
     });
   });
 

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -775,18 +775,10 @@ export function useMagicCircle(
   const handleReplay = useCallback(async () => {
     // リプレイ可能かチェック（描画ログがあり、リプレイ中でないこと）
     if (drawLogs.length === 0 || isReplayingRef.current) return;
-    
-    // 評価がまだ行われていない場合は先に評価を実行してスコアデータを取得
-    let result: ScoringResult | null = scoreResult;
-    if (!result && !showResult && isDrawing && userPath.length >= 10) {
-      // 評価を実行してスコアを取得
-      handleEvaluate();
-      // 評価完了を待つ（少し遅延させて状態更新を待機）
-      await new Promise(resolve => setTimeout(resolve, 100));
-      result = scoreResult;
-    }
-    
+
     // スコア結果がない場合はリプレイ用の履歴アイテムを作成できない
+    // （リプレイボタンは showResult=true のときのみ表示されるため scoreResult は必ず存在する）
+    const result: ScoringResult | null = scoreResult;
     if (!result) {
       setDebugMsg('スコアが計算されていないため、リプレイを保存できません');
       return;
@@ -861,7 +853,7 @@ export function useMagicCircle(
     // リプレイページに遷移
     const replayUrl = `/replay?data=${compressed}`;
     router.push(replayUrl);
-  }, [drawLogs, currentPattern, scoreResult, showResult, isDrawing, userPath, difficulty, handleEvaluate, router]);
+  }, [drawLogs, currentPattern, scoreResult, showResult, difficulty, router]);
 
   // ─── 魔法陣データの保存 ───
   /**
@@ -898,7 +890,6 @@ export function useMagicCircle(
    */
   const handleLoadData = useCallback((data: MagicCircleData) => {
     setSavedMagicData(data);
-    drawTemplate(currentPattern);
     setDrawLogs(data.drawLogs);
     setUserPath([]);
     drawTemplate(currentPattern);


### PR DESCRIPTION
## 概要

mainブランチ品質調査で検出された4件の問題（Issue #145〜#148）を一括修正します。

## 変更内容

### Fix #145 — HistoryDetail 再生コントロールを `<button>` に変更

**ファイル:** `src/components/HistoryDetail.tsx`

- 再生/停止コントロールを `<div onClick>` → `<button>` に変更
- `aria-label={isPlaying ? '⏹️ 停止' : '▶️ 再生'}` でアクセシブル名を明示
- `drawLogs` が空のとき `disabled` 属性を付与
- 共有ボタンに `aria-label="共有"` を追加（`title` → `aria-label`）

**効果:** キーボード操作で再生/停止が可能になり、アクセシビリティが向上

### Fix #146 — MagicCircleCanvas.test.tsx のボタン名を修正

**ファイル:** `src/components/MagicCircleCanvas.test.tsx`

| 修正前 | 修正後（コンポーネントの aria-label） |
|---|---|
| `"〈"` | `"前のパターン"` |
| `"〉"` | `"次のパターン"` |
| `"詠唱完了！"` | `"詠唱完了してスコアを判定する"` |

### Fix #147 — handleReplay のデッドコードを削除

**ファイル:** `src/hooks/useMagicCircle.ts`

到達不可能な auto-evaluate ブロック（行781〜787）を削除:
- `!result && !showResult && isDrawing` は UX フロー上同時に真にならない
- stale closure（100ms 待機で React 状態を読み直す）も併せて解消
- `useCallback` 依存配列を整理（`isDrawing`, `userPath`, `handleEvaluate` を削除）

### Fix #148 — handleLoadData の重複 drawTemplate 呼び出しを削除

**ファイル:** `src/hooks/useMagicCircle.ts`

`state` 変更前の冗長な1回目の `drawTemplate(currentPattern)` 呼び出しを削除。

## テスト結果

**修正前:** 19件失敗（`MagicCircleCanvas.test.tsx` 8件 + `HistoryDetail.test.tsx` 11件）
**修正後:** 206件全パス ✅

```
Test Files  10 passed (10)
Tests      206 passed (206)
```

## 関連 Issue

Fixes #145
Fixes #146
Fixes #147
Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)