### PR TITLE
fix: チャージ演出の微振動強化と細線化 (#150 フォローアップ)

### DIFF
--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -374,10 +374,10 @@ export function useMagicCircle(
       const startAngle = -Math.PI / 2;
 
       // ─── 微振動エフェクト ───
-      // 進行度に応じて振動幅を増加
-      const vibrationAmount = Math.sin(currentTime / 100) * (normalizedProgress * 0.08);
-      const baseLineWidth = 3;
-      const lineWidth = baseLineWidth + baseLineWidth * vibrationAmount;
+      // 進行度に応じて振動幅を増加（±30%まで広がる）
+      const vibrationAmount = Math.sin(currentTime / 80) * (normalizedProgress * 0.3);
+      const baseLineWidth = 1.5;
+      const lineWidth = Math.max(0.5, baseLineWidth * (1 + vibrationAmount));
 
       // ─── メイン円弧の描画 ───
       ctx.strokeStyle = 'rgba(0, 229, 255, 0.6)';


### PR DESCRIPTION
## 概要

PR #151（Issue #150）マージ後のフィードバックに対応しました。

## 修正内容

### 1. 微振動が弱すぎた問題の修正
**原因:** 振動幅の計算が `normalizedProgress * 0.08` だったため、進行度100%でもlineWidthの変動が最大 ±0.24px と極めて微小で体感できなかった。

**修正:**
- 振動幅: `0.08 → 0.3`（進行度100%時に ±30% の変動）
- 振動周期: `100ms → 80ms`（テンポを少し速く）

**変動範囲の比較:**
| 進行度 | 旧 | 新 |
|--------|-----|-----|
| 50% | 3 ± 0.12px | 1.5 ± 0.225px |
| 100% | 3 ± 0.24px | 1.5 ± 0.45px |

### 2. 線を細くした
- `baseLineWidth: 3 → 1.5`

## 関連
- Issue #150
- PR #151

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>