### PR TITLE
アプリ情報ページに戻るボタンを追加（Issue #155）

### DIFF
--- a/src/components/app-info.tsx
+++ b/src/components/app-info.tsx
@@ -1,11 +1,26 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
 export function AppInfo() {
+  const router = useRouter();
   const version = process.env.NEXT_PUBLIC_APP_VERSION || 'unknown';
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4" style={{ background: '#0d0d1a' }}>
-      <div className="max-w-md w-full p-8 rounded-xl border" style={{ borderColor: 'rgba(0,229,255,0.3)', background: 'rgba(13,13,26,0.97)' }}>
+      <div className="max-w-md w-full p-8 rounded-xl border relative" style={{ borderColor: 'rgba(0,229,255,0.3)', background: 'rgba(13,13,26,0.97)' }}>
+        <button
+          onClick={() => router.back()}
+          className="absolute top-4 left-4 flex h-8 w-8 items-center justify-center rounded-full text-sm transition-colors hover:bg-white/5"
+          style={{
+            border: '1px solid rgba(0,229,255,0.4)',
+            color: '#00e5ff',
+          }}
+          aria-label="戻る"
+        >
+          ←
+        </button>
+
         <h1 className="text-3xl font-bold text-center mb-6" style={{ color: '#00e5ff', textShadow: '0 0 20px rgba(0, 229, 255, 0.5)' }}>
           🔮 Arcane Tracer
         </h1>


### PR DESCRIPTION
## 問題
アプリ情報ページを開くと、閉じる手段がなくなるバグがありました。

## 解決方法
アプリ情報ページの左上に戻るボタン（←）を追加しました。

## 実装内容
- `useRouter` をインポート
- 左上に戻るボタンを追加
- `router.back()` で前ページに戻る機能を実装
- ボタンのスタイルは魔導書ページの戻るボタンと統一

## テスト
- ✅ ブラウザで確認：戻るボタンをクリックして、前ページに戻ることを確認
- ✅ ビルド：成功

Fixes #155