### PR TITLE
リプレイ画面の作成日時表示形式を改善（Issue #157）

### DIFF
--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -475,7 +475,13 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
 
   const formatDate = (ts: number): string => {
     const d = new Date(ts);
-    return d.toLocaleString('ja-JP');
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const date = String(d.getDate()).padStart(2, '0');
+    const hours = String(d.getHours()).padStart(2, '0');
+    const minutes = String(d.getMinutes()).padStart(2, '0');
+    const seconds = String(d.getSeconds()).padStart(2, '0');
+    return `${year}/${month}/${date} ${hours}:${minutes}:${seconds}`;
   };
 
   const formatTime = (ms: number): string => {


### PR DESCRIPTION
## 問題
リプレイ画面で表示される「作成日時」の形式が不一貫で、環境やロケール設定によって異なる可能性がありました。

## 解決方法
formatDate 関数を改善し、日時を明示的なフォーマット「YYYY/MM/DD HH:MM:SS」で統一しました。

## 実装内容
- `toLocaleString('ja-JP')` から明示的なフォーマットに変更
- 日時を「2024/12/31 23:59:59」形式で表示
- ローカルタイムで表示し、タイムゾーン問題に対応

## テスト
- ✅ ビルド成功
- ✅ formatDate 関数の動作確認

Fixes #157