### PR TITLE
チャージエフェクトの線の太さ蓄積を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3274,9 +3274,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3291,9 +3288,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3308,9 +3302,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3325,9 +3316,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3342,9 +3330,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3359,9 +3344,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3376,9 +3358,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3393,9 +3372,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3410,9 +3386,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3427,9 +3400,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3444,9 +3414,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3461,9 +3428,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3478,9 +3442,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -177,6 +177,9 @@ export function useMagicCircle(
   // チャージアニメーション用ref
   const chargeAnimRef = useRef<number | null>(null);
   const chargeStartTimeRef = useRef<number | null>(null);
+  // チャージアニメーション内のstale closure回避用ref
+  const drawLogsRef = useRef<DrawStroke[]>([]);
+  const userPathRef = useRef<{ x: number; y: number }[]>([]);
 
   // onCompletionUpdateはレンダリング毎に新しい参照になるためrefで保持（ループ防止）
   const onCompletionUpdateRef = useRef(onCompletionUpdate);
@@ -487,11 +490,16 @@ export function useMagicCircle(
 
       // 経過時間から進行度を計算
       const elapsed = now - chargeStartTimeRef.current;
-      // チャージは、時間が経つにつれて完了に向かう（initialTimeからactualTimeLeftへ）
-      // 進行度 = (経過時間) / (最大時間 * 1000)
       const progress = Math.min(1, elapsed / (maxTime * 1000));
 
-      // チャージ演出を描画（テンプレートはメイン描画ループで既に描画されている）
+      // 毎フレームキャンバスを再描画して重ね塗りによる線の太さ蓄積を防ぐ
+      drawTemplate(currentPattern);
+      if (drawLogsRef.current.length > 0) {
+        drawStrokes(drawLogsRef.current);
+      }
+      if (userPathRef.current.length >= 2) {
+        drawStrokes([userPathRef.current]);
+      }
       drawChargeEffect(currentPattern, progress, now);
 
       chargeAnimRef.current = requestAnimationFrame(animate);
@@ -506,7 +514,7 @@ export function useMagicCircle(
       }
       chargeStartTimeRef.current = null;
     };
-  }, [isActive, currentPattern, difficulty, drawChargeEffect]);
+  }, [isActive, currentPattern, difficulty, drawChargeEffect, drawTemplate, drawStrokes]);
 
   const getCanvasPos = useCallback((clientX: number, clientY: number) => {
     const canvas = canvasRef.current;
@@ -590,6 +598,8 @@ export function useMagicCircle(
   }, [isDrawing, startDrawing, draw, getCanvasPos]);
 
   useEffect(() => {
+    drawLogsRef.current = drawLogs;
+    userPathRef.current = userPath;
     if (!isReplayingRef.current) {
       // Draw completed strokes
       if (drawLogs.length > 0) {


### PR DESCRIPTION
## 概要

タイマーによる自動描画（チャージエフェクト）の円弧が太く見える問題を修正。

## 原因

チャージアニメーションのループがキャンバスをクリアせずに毎フレーム（60fps）円弧を重ね塗りしていた。
`lineWidth: 1.5` の半透明ストロークが何百回も積み重なることで、視覚的に非常に太い線に見えていた。

## 修正内容

`src/hooks/useMagicCircle.ts` のチャージアニメーションループを修正し、各フレームで以下の順に再描画するよう変更：

1. テンプレート再描画（`drawTemplate` によるキャンバスクリアを含む）
2. 完了済みユーザーストローク再描画
3. 描画中のユーザーパス再描画
4. チャージエフェクト（1回のみ）描画

また、アニメーションコールバック内での stale closure を避けるため `drawLogsRef` / `userPathRef` を追加。

## テスト確認事項

- [ ] チャージエフェクトの円弧が細く表示されること
- [ ] ユーザーの描画ストロークが正常に表示されること
- [ ] チャージアニメーション中にユーザーが描画できること
- [ ] リセット後に正常に動作すること

https://claude.ai/code/session_018ZAEes26no8yiGjoq2bbP9

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZAEes26no8yiGjoq2bbP9)_