### PR TITLE
fix: リプレイページで作成日時が「日時不明」になる問題を修正

### DIFF
--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -21,6 +21,7 @@ function buildHistory(flat: {
   difficulty: string;
   difficultyMultiplier: number;
   damageMultiplier: string;
+  createdAt?: number;
 }, idSeed: string): MagicCircleHistory {
   return {
     id: `replay_${idSeed.slice(0, 20)}`,
@@ -34,7 +35,7 @@ function buildHistory(flat: {
     difficulty: flat.difficulty,
     difficultyMultiplier: flat.difficultyMultiplier,
     damageMultiplier: flat.damageMultiplier,
-    createdAt: 0,
+    createdAt: flat.createdAt ?? 0,
   };
 }
 
@@ -49,6 +50,7 @@ function parseCompressed(compressed: string, idSeed: string): SyncResult {
     difficulty: string;
     difficultyMultiplier: number;
     damageMultiplier: string;
+    createdAt?: number;
   }>(compressed);
 
   if (!flat) return { loading: false, history: null, error: 'データの復元に失敗しました。共有リンクが無効または破損している可能性があります。' };

--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -404,6 +404,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       difficulty: history.difficulty,
       difficultyMultiplier: history.difficultyMultiplier,
       damageMultiplier: history.damageMultiplier,
+      createdAt: history.createdAt,
     };
     const compressed = compressForUrl(shareData);
     if (!compressed) return;
@@ -615,7 +616,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
             <div className="mb-4">
               <div className="text-sm text-gray-500">作成日時</div>
               <div className="text-sm" style={{ color: '#9c9caf' }}>
-                {history.createdAt ? formatDate(history.createdAt) : '日時不明'}
+                {history.createdAt != null && history.createdAt !== 0 ? formatDate(history.createdAt) : '日時不明'}
               </div>
             </div>
 

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -421,6 +421,7 @@ export default function HistoryPanel({ isOpen, onClose, onSelect }: HistoryPanel
                             difficulty: h.difficulty,
                             difficultyMultiplier: h.difficultyMultiplier,
                             damageMultiplier: h.damageMultiplier,
+                            createdAt: h.createdAt,
                           };
                           const compressed = compressForUrl(shareData);
                           if (!compressed) return;

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -973,6 +973,7 @@ export function useMagicCircle(
       difficulty: historyItem.difficulty,
       difficultyMultiplier: historyItem.difficultyMultiplier,
       damageMultiplier: historyItem.damageMultiplier,
+      createdAt: historyItem.createdAt,
     };
 
     // 履歴データをURL用に圧縮


### PR DESCRIPTION
## 概要

リプレイページ（共有URL経由）で「作成日時」が常に「日時不明」と表示される問題を修正。

## 原因

共有データを URL 圧縮する際に `createdAt` フィールドが含まれておらず、リプレイページで復元した履歴の `createdAt` が `0`（falsy）になっていた。

具体的には以下の 3 箇所で `createdAt` が共有データに含まれていなかった：
- `useMagicCircle.ts` の `dataForCompression`
- `HistoryDetail.tsx` の `handleShare`
- `HistoryPanel.tsx` の share ボタンハンドラ

また `replay/page.tsx` の `buildHistory()` が `createdAt: 0` をハードコードしており、`parseCompressed()` の型定義にも `createdAt` が欠けていた。

## 変更内容

- `useMagicCircle.ts`: URL圧縮データに `createdAt` を追加
- `HistoryDetail.tsx`: 共有データに `createdAt` を追加、表示条件を `!= null && !== 0` に厳密化
- `HistoryPanel.tsx`: 共有データに `createdAt` を追加
- `replay/page.tsx`: `buildHistory` と `parseCompressed` の型に `createdAt?: number` を追加し、デコードした値を使用するよう修正

## テスト計画

- [ ] 新しい共有URLを生成してリプレイページで作成日時が正しく表示されること
- [ ] 旧形式（`createdAt` なし）の共有URLでは「日時不明」が表示されること（後方互換）
- [ ] TypeScript 型チェックがエラーなしで通ること

https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau

---
_Generated by [Claude Code](https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau)_