### PR TITLE
feat: マルチモード追加・コンボモードアンロック機能

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,36 +3,59 @@
 import { Suspense, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import MagicCircleCanvas from '@/components/MagicCircleCanvas';
+import ModeSelectScreen, { type GameMode } from '@/components/ModeSelectScreen';
+import MultiModeGame from '@/components/MultiModeGame';
 import { ScoringResult } from '@/lib/scoring';
+import type { Difficulty } from '@/lib/patterns';
+
+type AppScreen =
+  | { type: 'mode-select' }
+  | { type: 'single' }
+  | { type: 'multi'; difficulty: Difficulty }
+  | { type: 'combo'; difficulty: Difficulty };
 
 function HomeContent() {
   const searchParams = useSearchParams();
-  const [lastResult, setLastResult] = useState<ScoringResult | null>(null);
-  const [completionStatus, setCompletionStatus] = useState<{ completed: number; total: number } | null>(null);
-
-  const handleScore = (result: ScoringResult) => {
-    setLastResult(result);
-  };
-
-  const handleReset = () => {
-    setLastResult(null);
-  };
-
-  const handleCompletionUpdate = (status: { completed: number; total: number } | null) => {
-    setCompletionStatus(status);
-  };
-
-  // URLパラメータからパターン名を取得（再編集用）
   const patternParam = searchParams.get('pattern');
   const initialPatternName = patternParam ? decodeURIComponent(patternParam) : undefined;
 
+  // 再編集URLからの遷移は直接シングルモードへ
+  const [screen, setScreen] = useState<AppScreen>(
+    initialPatternName ? { type: 'single' } : { type: 'mode-select' }
+  );
+
+  const [lastResult, setLastResult] = useState<ScoringResult | null>(null);
+  const [completionStatus, setCompletionStatus] = useState<{
+    completed: number;
+    total: number;
+  } | null>(null);
+
+  const handleModeSelect = (mode: GameMode, difficulty?: Difficulty) => {
+    if (mode === 'single') {
+      setScreen({ type: 'single' });
+    } else if (mode === 'multi') {
+      setScreen({ type: 'multi', difficulty: difficulty ?? 'normal' });
+    } else if (mode === 'combo') {
+      setScreen({ type: 'combo', difficulty: difficulty ?? 'normal' });
+    }
+  };
+
+  const goToModeSelect = () => {
+    setLastResult(null);
+    setScreen({ type: 'mode-select' });
+  };
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4" style={{ background: '#0d0d1a' }}>
+    <div
+      className="min-h-screen flex flex-col items-center justify-center p-4"
+      style={{ background: '#0d0d1a' }}
+    >
       <header className="mb-4 text-center">
         <h1
           className="text-4xl font-bold tracking-wide"
           style={{
-            textShadow: '0 0 20px rgba(0, 229, 255, 0.5), 0 0 40px rgba(0, 229, 255, 0.3)',
+            textShadow:
+              '0 0 20px rgba(0, 229, 255, 0.5), 0 0 40px rgba(0, 229, 255, 0.3)',
             color: '#00e5ff',
           }}
         >
@@ -41,30 +64,56 @@ function HomeContent() {
         <p className="text-gray-400 mt-2 text-sm">詠唱の正確さが威力になる</p>
       </header>
 
-      <MagicCircleCanvas
-        onScore={handleScore}
-        onReset={handleReset}
-        onCompletionUpdate={handleCompletionUpdate}
-        initialPatternName={initialPatternName}
-      />
-
-      {lastResult && (
-        <div className="mt-4 text-center">
-          <div className="text-lg" style={{ color: '#7c4dff' }}>
-            前回の結果: <span className="font-bold">{lastResult.rank}</span>{' '}
-            (スコア: {lastResult.score}, 倍率: {lastResult.difficultyMultiplier}x, {lastResult.damageMultiplier}ダメージ)
-          </div>
-        </div>
+      {/* モード選択 */}
+      {screen.type === 'mode-select' && (
+        <ModeSelectScreen onSelect={handleModeSelect} />
       )}
 
-      {/* 完了状況表示 */}
-      {completionStatus && (
-        <div className="mt-4 text-center text-sm text-gray-400">
-          魔法陣修得: {completionStatus.completed} / {completionStatus.total}
-          {completionStatus.completed === completionStatus.total &&
-            <span className="text-lg font-bold text-green-500 ml-2">🎉 全制覇！</span>
-          }
-        </div>
+      {/* シングルモード */}
+      {screen.type === 'single' && (
+        <>
+          <button
+            onClick={goToModeSelect}
+            className="mb-2 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            ← モード選択に戻る
+          </button>
+          <MagicCircleCanvas
+            onScore={setLastResult}
+            onReset={() => setLastResult(null)}
+            onCompletionUpdate={setCompletionStatus}
+            initialPatternName={initialPatternName}
+          />
+          {lastResult && (
+            <div className="mt-4 text-center">
+              <div className="text-lg" style={{ color: '#7c4dff' }}>
+                前回の結果:{' '}
+                <span className="font-bold">{lastResult.rank}</span>{' '}
+                (スコア: {lastResult.score}, 倍率:{' '}
+                {lastResult.difficultyMultiplier}x, {lastResult.damageMultiplier}
+                ダメージ)
+              </div>
+            </div>
+          )}
+          {completionStatus && (
+            <div className="mt-4 text-center text-sm text-gray-400">
+              魔法陣修得: {completionStatus.completed} / {completionStatus.total}
+              {completionStatus.completed === completionStatus.total && (
+                <span className="text-lg font-bold text-green-500 ml-2">
+                  🎉 全制覇！
+                </span>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* マルチモード / コンボモード（現時点はコンボもマルチと同じゲームロジック） */}
+      {(screen.type === 'multi' || screen.type === 'combo') && (
+        <MultiModeGame
+          difficulty={screen.difficulty}
+          onExit={goToModeSelect}
+        />
       )}
     </div>
   );
@@ -72,11 +121,16 @@ function HomeContent() {
 
 export default function Home() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen flex flex-col items-center justify-center p-4" style={{ background: '#0d0d1a' }}>
-        <div className="text-gray-400">読み込み中...</div>
-      </div>
-    }>
+    <Suspense
+      fallback={
+        <div
+          className="min-h-screen flex flex-col items-center justify-center p-4"
+          style={{ background: '#0d0d1a' }}
+        >
+          <div className="text-gray-400">読み込み中...</div>
+        </div>
+      }
+    >
       <HomeContent />
     </Suspense>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import MagicCircleCanvas from '@/components/MagicCircleCanvas';
-import ModeSelectScreen, { type GameMode } from '@/components/ModeSelectScreen';
 import MultiModeGame from '@/components/MultiModeGame';
+import UnlockModal from '@/components/UnlockModal';
 import { ScoringResult } from '@/lib/scoring';
 import type { Difficulty } from '@/lib/patterns';
+import {
+  getAllUnlockStatus,
+  checkPlayBasedUnlocks,
+  type UnlockInfo,
+} from '@/lib/unlocks';
+import { getAllHistories } from '@/lib/historyDB';
 
 type AppScreen =
-  | { type: 'mode-select' }
   | { type: 'single' }
   | { type: 'multi'; difficulty: Difficulty }
   | { type: 'combo'; difficulty: Difficulty };
@@ -19,37 +24,66 @@ function HomeContent() {
   const patternParam = searchParams.get('pattern');
   const initialPatternName = patternParam ? decodeURIComponent(patternParam) : undefined;
 
-  // 再編集URLからの遷移は直接シングルモードへ
-  const [screen, setScreen] = useState<AppScreen>(
-    initialPatternName ? { type: 'single' } : { type: 'mode-select' }
-  );
-
+  const [screen, setScreen] = useState<AppScreen>({ type: 'single' });
   const [lastResult, setLastResult] = useState<ScoringResult | null>(null);
   const [completionStatus, setCompletionStatus] = useState<{
     completed: number;
     total: number;
   } | null>(null);
+  const [unlocks, setUnlocks] = useState(() => getAllUnlockStatus());
+  const [unlockQueue, setUnlockQueue] = useState<UnlockInfo[]>([]);
+  const initCheckedRef = useRef(false);
 
-  const handleModeSelect = (mode: GameMode, difficulty?: Difficulty) => {
-    if (mode === 'single') {
-      setScreen({ type: 'single' });
-    } else if (mode === 'multi') {
-      setScreen({ type: 'multi', difficulty: difficulty ?? 'normal' });
-    } else if (mode === 'combo') {
-      setScreen({ type: 'combo', difficulty: difficulty ?? 'normal' });
-    }
-  };
+  // 初回マウント時: 既存プレイ数でアンロックを付与（既存ユーザー対応）
+  useEffect(() => {
+    if (initCheckedRef.current) return;
+    initCheckedRef.current = true;
+    getAllHistories().then((histories) => {
+      const newUnlocks = checkPlayBasedUnlocks(histories.length);
+      if (newUnlocks.length > 0) {
+        setUnlockQueue((q) => [...q, ...newUnlocks]);
+        setUnlocks(getAllUnlockStatus());
+      }
+    }).catch(() => { /* ignore */ });
+  }, []);
 
-  const goToModeSelect = () => {
+  const handleScore = useCallback(async (result: ScoringResult) => {
+    setLastResult(result);
+    try {
+      const histories = await getAllHistories();
+      const newUnlocks = checkPlayBasedUnlocks(histories.length);
+      if (newUnlocks.length > 0) {
+        setUnlockQueue((q) => [...q, ...newUnlocks]);
+        setUnlocks(getAllUnlockStatus());
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  const handleSwitchMode = useCallback((mode: 'multi' | 'combo', difficulty: Difficulty) => {
     setLastResult(null);
-    setScreen({ type: 'mode-select' });
-  };
+    setScreen({ type: mode, difficulty });
+  }, []);
+
+  const handleMultiExit = useCallback(() => {
+    // マルチモード終了時にアンロック状態を再取得（コンボ解放反映）
+    setUnlocks(getAllUnlockStatus());
+    setScreen({ type: 'single' });
+  }, []);
+
+  const dismissUnlock = useCallback(() => {
+    setUnlockQueue((q) => q.slice(1));
+  }, []);
 
   return (
     <div
       className="min-h-screen flex flex-col items-center justify-center p-4"
       style={{ background: '#0d0d1a' }}
     >
+      {/* アンロック通知（キュー先頭を表示） */}
+      {unlockQueue.length > 0 && (
+        <UnlockModal unlock={unlockQueue[0]} onClose={dismissUnlock} />
+      )}
+
       <header className="mb-4 text-center">
         <h1
           className="text-4xl font-bold tracking-wide"
@@ -64,25 +98,16 @@ function HomeContent() {
         <p className="text-gray-400 mt-2 text-sm">詠唱の正確さが威力になる</p>
       </header>
 
-      {/* モード選択 */}
-      {screen.type === 'mode-select' && (
-        <ModeSelectScreen onSelect={handleModeSelect} />
-      )}
-
       {/* シングルモード */}
       {screen.type === 'single' && (
         <>
-          <button
-            onClick={goToModeSelect}
-            className="mb-2 text-xs text-gray-500 hover:text-gray-300 transition-colors"
-          >
-            ← モード選択に戻る
-          </button>
           <MagicCircleCanvas
-            onScore={setLastResult}
+            onScore={handleScore}
             onReset={() => setLastResult(null)}
             onCompletionUpdate={setCompletionStatus}
             initialPatternName={initialPatternName}
+            unlocks={unlocks}
+            onSwitchMode={handleSwitchMode}
           />
           {lastResult && (
             <div className="mt-4 text-center">
@@ -108,11 +133,11 @@ function HomeContent() {
         </>
       )}
 
-      {/* マルチモード / コンボモード（現時点はコンボもマルチと同じゲームロジック） */}
+      {/* マルチモード / コンボモード */}
       {(screen.type === 'multi' || screen.type === 'combo') && (
         <MultiModeGame
           difficulty={screen.difficulty}
-          onExit={goToModeSelect}
+          onExit={handleMultiExit}
         />
       )}
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,6 +136,7 @@ function HomeContent() {
       {/* マルチモード / コンボモード */}
       {(screen.type === 'multi' || screen.type === 'combo') && (
         <MultiModeGame
+          mode={screen.type}
           difficulty={screen.difficulty}
           onExit={handleMultiExit}
         />

--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -21,6 +21,7 @@ function buildHistory(flat: {
   difficulty: string;
   difficultyMultiplier: number;
   damageMultiplier: string;
+  createdAt?: number;
 }, idSeed: string): MagicCircleHistory {
   return {
     id: `replay_${idSeed.slice(0, 20)}`,
@@ -34,7 +35,7 @@ function buildHistory(flat: {
     difficulty: flat.difficulty,
     difficultyMultiplier: flat.difficultyMultiplier,
     damageMultiplier: flat.damageMultiplier,
-    createdAt: 0,
+    createdAt: flat.createdAt ?? 0,
   };
 }
 
@@ -49,6 +50,7 @@ function parseCompressed(compressed: string, idSeed: string): SyncResult {
     difficulty: string;
     difficultyMultiplier: number;
     damageMultiplier: string;
+    createdAt?: number;
   }>(compressed);
 
   if (!flat) return { loading: false, history: null, error: 'データの復元に失敗しました。共有リンクが無効または破損している可能性があります。' };

--- a/src/components/HistoryDetail.tsx
+++ b/src/components/HistoryDetail.tsx
@@ -404,6 +404,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
       difficulty: history.difficulty,
       difficultyMultiplier: history.difficultyMultiplier,
       damageMultiplier: history.damageMultiplier,
+      createdAt: history.createdAt,
     };
     const compressed = compressForUrl(shareData);
     if (!compressed) return;
@@ -615,7 +616,7 @@ export default function HistoryDetail({ history, onClose, onReEdit }: HistoryDet
             <div className="mb-4">
               <div className="text-sm text-gray-500">作成日時</div>
               <div className="text-sm" style={{ color: '#9c9caf' }}>
-                {history.createdAt ? formatDate(history.createdAt) : '日時不明'}
+                {history.createdAt != null && history.createdAt !== 0 ? formatDate(history.createdAt) : '日時不明'}
               </div>
             </div>
 

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -421,6 +421,7 @@ export default function HistoryPanel({ isOpen, onClose, onSelect }: HistoryPanel
                             difficulty: h.difficulty,
                             difficultyMultiplier: h.difficultyMultiplier,
                             damageMultiplier: h.damageMultiplier,
+                            createdAt: h.createdAt,
                           };
                           const compressed = compressForUrl(shareData);
                           if (!compressed) return;

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -28,6 +28,8 @@ export default function MagicCircleCanvas({
   /** 完了状況更新時のコールバック（オプション） */
   onCompletionUpdate,
   initialPatternName,
+  unlocks,
+  onSwitchMode,
 }: {
   /** スコア計算完了時のコールバック */
   onScore: (result: ScoringResult) => void;
@@ -40,6 +42,15 @@ export default function MagicCircleCanvas({
   /** 完了状況更新時のコールバック（オプション） */
   onCompletionUpdate?: (status: { completed: number; total: number } | null) => void;
   initialPatternName?: string;
+  /** アンロック済み機能フラグ */
+  unlocks?: {
+    history?: boolean;
+    grimoire?: boolean;
+    multiMode?: boolean;
+    comboMode?: boolean;
+  };
+  /** モード切替コールバック */
+  onSwitchMode?: (mode: 'multi' | 'combo', difficulty: Difficulty) => void;
 }) {
   const router = useRouter();
 
@@ -128,23 +139,49 @@ export default function MagicCircleCanvas({
             className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
             style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
           >
-            {/* 魔導書 */}
-            <button
-              onClick={() => { router.push('/grimoire'); setShowMenu(false); }}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-              style={{ color: '#00e5ff' }}
-            >
-              📖 魔導書
-            </button>
+            {/* マルチモード（アンロック済みのみ） */}
+            {unlocks?.multiMode && (
+              <button
+                onClick={() => { onSwitchMode?.('multi', difficulty); setShowMenu(false); }}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+                style={{ color: '#7c4dff' }}
+              >
+                ⚡ マルチモード
+              </button>
+            )}
 
-            {/* 作成履歴 */}
-            <button
-              onClick={() => { setShowHistory(true); setShowMenu(false); }}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-              style={{ color: '#7c4dff' }}
-            >
-              📜 作成履歴
-            </button>
+            {/* コンボモード（アンロック済みのみ） */}
+            {unlocks?.comboMode && (
+              <button
+                onClick={() => { onSwitchMode?.('combo', difficulty); setShowMenu(false); }}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+                style={{ color: '#ffd700' }}
+              >
+                🔥 コンボモード
+              </button>
+            )}
+
+            {/* 魔導書（アンロック済みのみ） */}
+            {unlocks?.grimoire && (
+              <button
+                onClick={() => { router.push('/grimoire'); setShowMenu(false); }}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+                style={{ color: '#00e5ff' }}
+              >
+                📖 魔導書
+              </button>
+            )}
+
+            {/* 作成履歴（アンロック済みのみ） */}
+            {unlocks?.history && (
+              <button
+                onClick={() => { setShowHistory(true); setShowMenu(false); }}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+                style={{ color: '#00e5ff' }}
+              >
+                📜 作成履歴
+              </button>
+            )}
 
             {/* レベル変更 */}
             <div className="px-3 py-2">

--- a/src/components/ModeSelectScreen.tsx
+++ b/src/components/ModeSelectScreen.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { isComboModeUnlocked, getQualifyCount } from '@/lib/unlocks';
+import type { Difficulty } from '@/lib/patterns';
+
+export type GameMode = 'single' | 'multi' | 'combo';
+
+const DIFFICULTIES: { value: Difficulty; label: string; color: string }[] = [
+  { value: 'easy',   label: 'EASY',   color: '#76ff03' },
+  { value: 'normal', label: 'NORMAL', color: '#00e5ff' },
+  { value: 'hard',   label: 'HARD',   color: '#ff9100' },
+  { value: 'expert', label: 'EXPERT', color: '#ff4081' },
+];
+
+interface Props {
+  onSelect: (mode: GameMode, difficulty?: Difficulty) => void;
+}
+
+export default function ModeSelectScreen({ onSelect }: Props) {
+  const [comboUnlocked, setComboUnlocked] = useState(false);
+  const [qualifyCount, setQualifyCount] = useState(0);
+  const [pendingMode, setPendingMode] = useState<GameMode | null>(null);
+
+  useEffect(() => {
+    setComboUnlocked(isComboModeUnlocked());
+    setQualifyCount(getQualifyCount());
+  }, []);
+
+  // シングルモードは難易度選択なし（ゲーム内で変更可）
+  if (pendingMode === 'single') {
+    onSelect('single');
+    return null;
+  }
+
+  // マルチ/コンボモードの難易度選択
+  if (pendingMode === 'multi' || pendingMode === 'combo') {
+    return (
+      <div className="flex flex-col items-center gap-4 p-4 w-full max-w-sm">
+        <button
+          onClick={() => setPendingMode(null)}
+          className="self-start text-xs text-gray-500 hover:text-gray-300 transition-colors"
+        >
+          ← 戻る
+        </button>
+        <p className="text-sm text-gray-400">難易度を選択</p>
+        {DIFFICULTIES.map(({ value, label, color }) => (
+          <button
+            key={value}
+            onClick={() => onSelect(pendingMode, value)}
+            className="w-full rounded-xl border-2 p-4 text-left transition-all hover:scale-105 active:scale-95"
+            style={{ borderColor: color, background: `${color}10` }}
+          >
+            <span className="text-lg font-bold" style={{ color }}>{label}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4 w-full max-w-sm">
+      <p className="text-sm text-gray-400">ゲームモードを選択</p>
+
+      {/* シングルモード */}
+      <button
+        onClick={() => setPendingMode('single')}
+        className="w-full rounded-xl border-2 p-5 text-left transition-all hover:scale-105 active:scale-95"
+        style={{ borderColor: '#00e5ff', background: 'rgba(0,229,255,0.05)' }}
+      >
+        <div className="text-xl font-bold mb-1" style={{ color: '#00e5ff' }}>⚔️ シングルモード</div>
+        <p className="text-sm text-gray-400">1枚の魔法陣を丁寧に詠唱する</p>
+      </button>
+
+      {/* マルチモード */}
+      <button
+        onClick={() => setPendingMode('multi')}
+        className="w-full rounded-xl border-2 p-5 text-left transition-all hover:scale-105 active:scale-95"
+        style={{ borderColor: '#7c4dff', background: 'rgba(124,77,255,0.05)' }}
+      >
+        <div className="text-xl font-bold mb-1" style={{ color: '#7c4dff' }}>⚡ マルチモード</div>
+        <p className="text-sm text-gray-400">時間制限内に何枚もの魔法陣を詠唱する</p>
+        {!comboUnlocked && qualifyCount > 0 && (
+          <p className="text-xs mt-1" style={{ color: '#ffd700' }}>
+            コンボ解放まであと {3 - qualifyCount} 回
+          </p>
+        )}
+      </button>
+
+      {/* コンボモード（解放済み or 施錠表示） */}
+      {comboUnlocked ? (
+        <button
+          onClick={() => setPendingMode('combo')}
+          className="w-full rounded-xl border-2 p-5 text-left transition-all hover:scale-105 active:scale-95"
+          style={{ borderColor: '#ffd700', background: 'rgba(255,215,0,0.05)' }}
+        >
+          <div className="text-xl font-bold mb-1" style={{ color: '#ffd700' }}>🔥 コンボモード</div>
+          <p className="text-sm text-gray-400">連続高得点でコンボ倍率アップ！（Coming soon）</p>
+        </button>
+      ) : (
+        <div
+          className="w-full rounded-xl border-2 p-5 opacity-40 cursor-not-allowed select-none"
+          style={{ borderColor: '#555', background: 'rgba(85,85,85,0.05)' }}
+        >
+          <div className="text-xl font-bold mb-1 text-gray-500">🔒 ???</div>
+          <p className="text-sm text-gray-600">マルチモードで腕を磨くと解放される</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -9,42 +9,69 @@ import {
   MULTI_MODE_BONUS_TIME,
   MULTI_MODE_RESULT_DISPLAY_MS,
   calcOverallRank,
+  getComboMultiplier,
 } from '@/lib/multiModeConstants';
 import MultiModeResult from './MultiModeResult';
 
 interface Props {
+  mode: 'multi' | 'combo';
   difficulty: Difficulty;
   onExit: () => void;
 }
 
-export default function MultiModeGame({ difficulty, onExit }: Props) {
+export default function MultiModeGame({ mode, difficulty, onExit }: Props) {
   const initialTime = MULTI_MODE_INITIAL_TIME[difficulty];
+  const isCombo = mode === 'combo';
 
   const [globalTimeLeft, setGlobalTimeLeft] = useState(initialTime);
   const [isGameRunning, setIsGameRunning] = useState(true);
   const [circlesCleared, setCirclesCleared] = useState(0);
   const [scores, setScores] = useState<ScoringResult[]>([]);
   const [autoAdvancing, setAutoAdvancing] = useState(false);
+  const [comboCount, setComboCount] = useState(0);
+  const [comboBreak, setComboBreak] = useState(false);
   const [gameResult, setGameResult] = useState<import('./MultiModeResult').MultiModeGameResult | null>(null);
 
-  // stale closure 回避用 ref
   const globalTimeLeftRef = useRef(globalTimeLeft);
   const scoresRef = useRef(scores);
   const circlesClearedRef = useRef(circlesCleared);
+  const comboCountRef = useRef(0);
+  const maxComboRef = useRef(0);
   const gameEndedRef = useRef(false);
 
   useEffect(() => { globalTimeLeftRef.current = globalTimeLeft; }, [globalTimeLeft]);
   useEffect(() => { scoresRef.current = scores; }, [scores]);
   useEffect(() => { circlesClearedRef.current = circlesCleared; }, [circlesCleared]);
 
-  // 1枚クリア時のスコアコールバック（useMagicCircle に渡す）
   const handleCircleScore = useCallback((result: ScoringResult) => {
-    setScores(prev => [...prev, result]);
+    let storedResult = result;
+
+    if (isCombo) {
+      // コンボ倍率を現在のストリークに基づいて適用
+      const currentCombo = comboCountRef.current;
+      const mult = getComboMultiplier(currentCombo);
+      storedResult = { ...result, score: Math.round(result.score * mult) };
+
+      // ランクに基づいてストリーク更新
+      if (result.rank === 'S' || result.rank === 'A') {
+        comboCountRef.current = currentCombo + 1;
+        setComboBreak(false);
+      } else {
+        if (currentCombo > 0) setComboBreak(true);
+        comboCountRef.current = 0;
+      }
+
+      if (comboCountRef.current > maxComboRef.current) {
+        maxComboRef.current = comboCountRef.current;
+      }
+      setComboCount(comboCountRef.current);
+    }
+
+    setScores(prev => [...prev, storedResult]);
     setCirclesCleared(prev => prev + 1);
-    // クリアボーナス加算（初期時間を上限）
     setGlobalTimeLeft(prev => Math.min(prev + MULTI_MODE_BONUS_TIME, initialTime));
     setAutoAdvancing(true);
-  }, [initialTime]);
+  }, [isCombo, initialTime]);
 
   const {
     canvasRef, canvasSize,
@@ -54,7 +81,6 @@ export default function MultiModeGame({ difficulty, onExit }: Props) {
     isReplaying, patternName, getRankColor,
   } = useMagicCircle(handleCircleScore, () => {});
 
-  // 難易度を同期（generateRandomPattern が正しい難易度でパターンを生成するよう）
   useEffect(() => {
     changeDifficulty(difficulty);
   }, [difficulty, changeDifficulty]);
@@ -65,77 +91,82 @@ export default function MultiModeGame({ difficulty, onExit }: Props) {
     const timer = setTimeout(() => {
       handleNext();
       setAutoAdvancing(false);
+      setComboBreak(false);
     }, MULTI_MODE_RESULT_DISPLAY_MS);
     return () => clearTimeout(timer);
   }, [autoAdvancing, handleNext]);
 
-  // 1枚ごとのタイムアウト → 自動評価または自動スキップ
+  // 1枚ごとのタイムアウト → 自動評価またはスキップ
   useEffect(() => {
     if (timeLeft > 0 || isActive || showResult || !isGameRunning || autoAdvancing) return;
     const timer = setTimeout(() => {
       if (userPath.length > 0) {
-        handleEvaluate(); // onScore → handleCircleScore → autoAdvancing
+        handleEvaluate();
       } else {
-        handleNext(); // 何も描かなかった場合はスキップ
+        if (isCombo && comboCountRef.current > 0) {
+          comboCountRef.current = 0;
+          setComboCount(0);
+          setComboBreak(true);
+        }
+        handleNext();
       }
     }, 600);
     return () => clearTimeout(timer);
-  }, [timeLeft, isActive, showResult, isGameRunning, autoAdvancing, userPath.length, handleEvaluate, handleNext]);
+  }, [timeLeft, isActive, showResult, isGameRunning, autoAdvancing, userPath.length, handleEvaluate, handleNext, isCombo]);
 
   // グローバルタイマー
   useEffect(() => {
     if (!isGameRunning) return;
     const interval = setInterval(() => {
       setGlobalTimeLeft(prev => {
-        if (prev <= 1) {
-          setIsGameRunning(false);
-          return 0;
-        }
+        if (prev <= 1) { setIsGameRunning(false); return 0; }
         return prev - 1;
       });
     }, 1000);
     return () => clearInterval(interval);
   }, [isGameRunning]);
 
-  // グローバルタイマーが 0 → ゲーム終了
+  // タイマー 0 → ゲーム終了
   useEffect(() => {
     if (!isGameRunning && globalTimeLeft === 0 && !gameEndedRef.current) {
       gameEndedRef.current = true;
-      endGame(0);
+      buildAndSetResult(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isGameRunning, globalTimeLeft]);
 
-  const endGame = useCallback((timeLeftOnEnd: number) => {
+  const buildAndSetResult = useCallback((timeLeftOnEnd: number) => {
     const currentScores = scoresRef.current;
     const avgScore =
       currentScores.length > 0
         ? currentScores.reduce((sum, r) => sum + r.score, 0) / currentScores.length
         : 0;
     setGameResult({
+      mode,
       circlesCleared: circlesClearedRef.current,
       scores: currentScores,
       avgScore,
       overallRank: calcOverallRank(avgScore),
       timeLeftOnEnd,
       difficulty,
+      maxCombo: maxComboRef.current,
     });
-  }, [difficulty]);
+  }, [mode, difficulty]);
 
   const handleEndSession = useCallback(() => {
     if (gameEndedRef.current) return;
     gameEndedRef.current = true;
     setIsGameRunning(false);
-    endGame(globalTimeLeftRef.current);
-  }, [endGame]);
+    buildAndSetResult(globalTimeLeftRef.current);
+  }, [buildAndSetResult]);
 
   if (gameResult) {
     return <MultiModeResult result={gameResult} onExit={onExit} />;
   }
 
   const timerPercent = (globalTimeLeft / initialTime) * 100;
-  const timerColor =
-    timerPercent > 50 ? '#76ff03' : timerPercent > 25 ? '#ff9100' : '#ff4081';
+  const timerColor = timerPercent > 50 ? '#76ff03' : timerPercent > 25 ? '#ff9100' : '#ff4081';
+  const currentMult = isCombo ? getComboMultiplier(comboCount) : 1;
 
   return (
     <div className="flex flex-col items-center gap-4 p-4">
@@ -164,16 +195,36 @@ export default function MultiModeGame({ difficulty, onExit }: Props) {
         </div>
       </div>
 
+      {/* コンボ倍率インジケーター（コンボモードのみ） */}
+      {isCombo && (
+        <div className="flex items-center gap-3">
+          <div
+            className={`text-lg font-bold tabular-nums transition-all ${comboCount > 0 ? 'scale-110' : ''}`}
+            style={{ color: comboCount > 0 ? '#ffd700' : '#555' }}
+          >
+            COMBO ×{currentMult.toFixed(1)}
+          </div>
+          {comboCount > 0 && (
+            <div className="text-xs px-2 py-0.5 rounded-full font-bold"
+              style={{ background: '#ffd70022', color: '#ffd700', border: '1px solid #ffd70066' }}>
+              {comboCount}連続
+            </div>
+          )}
+          {comboBreak && comboCount === 0 && (
+            <div className="text-xs font-bold animate-pulse" style={{ color: '#ff4081' }}>
+              BREAK!
+            </div>
+          )}
+        </div>
+      )}
+
       {/* パターン名 */}
       <div className="text-sm font-bold" style={{ color: '#7c4dff' }}>
         {patternName || '準備中...'}
       </div>
 
       {/* キャンバス */}
-      <div
-        className="relative w-[350px] max-w-full"
-        style={{ touchAction: 'none' }}
-      >
+      <div className="relative w-[350px] max-w-full" style={{ touchAction: 'none' }}>
         <canvas
           ref={canvasRef}
           width={canvasSize}
@@ -191,37 +242,40 @@ export default function MultiModeGame({ difficulty, onExit }: Props) {
           onPointerLeave={onPointerUp}
         />
 
-        {/* 1枚クリア時の結果オーバーレイ（自動遷移） */}
+        {/* 1枚クリア結果オーバーレイ */}
         {showResult && scoreResult && (
           <div
             className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-lg"
             style={{ background: 'rgba(13,13,26,0.93)' }}
           >
-            <div
-              className="text-7xl font-bold"
-              style={{ color: getRankColor(scoreResult.rank) }}
-            >
+            <div className="text-7xl font-bold" style={{ color: getRankColor(scoreResult.rank) }}>
               {scoreResult.rank}
             </div>
-            <div className="text-3xl font-bold text-white">{scoreResult.score}点</div>
-            <div className="text-sm" style={{ color: '#76ff03' }}>
-              +{MULTI_MODE_BONUS_TIME}秒 ボーナス
+            <div className="text-3xl font-bold text-white">
+              {isCombo && getComboMultiplier(comboCountRef.current - (scoreResult.rank === 'S' || scoreResult.rank === 'A' ? 1 : 0)) > 1
+                ? <>
+                    <span className="text-lg text-gray-400 line-through mr-2">{scoreResult.score}</span>
+                    <span>{Math.round(scoreResult.score)}点</span>
+                  </>
+                : <>{scoreResult.score}点</>
+              }
             </div>
-            <div className="text-xs text-gray-400 animate-pulse mt-1">
-              次の魔法陣へ...
-            </div>
+            {isCombo && comboCount > 0 && (
+              <div className="text-sm font-bold" style={{ color: '#ffd700' }}>
+                ×{currentMult.toFixed(1)} コンボ！
+              </div>
+            )}
+            <div className="text-sm" style={{ color: '#76ff03' }}>+{MULTI_MODE_BONUS_TIME}秒 ボーナス</div>
+            <div className="text-xs text-gray-400 animate-pulse mt-1">次の魔法陣へ...</div>
           </div>
         )}
 
-        {/* グローバルタイマー終了オーバーレイ */}
         {!isGameRunning && globalTimeLeft === 0 && !gameResult && (
           <div
             className="absolute inset-0 flex flex-col items-center justify-center rounded-lg"
             style={{ background: 'rgba(13,13,26,0.93)' }}
           >
-            <div className="text-2xl font-bold" style={{ color: '#ff4081' }}>
-              ⏰ 時間終了！
-            </div>
+            <div className="text-2xl font-bold" style={{ color: '#ff4081' }}>⏰ 時間終了！</div>
           </div>
         )}
       </div>

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useMagicCircle } from '@/hooks/useMagicCircle';
+import type { ScoringResult } from '@/lib/scoring';
+import type { Difficulty } from '@/lib/patterns';
+import {
+  MULTI_MODE_INITIAL_TIME,
+  MULTI_MODE_BONUS_TIME,
+  MULTI_MODE_RESULT_DISPLAY_MS,
+  calcOverallRank,
+} from '@/lib/multiModeConstants';
+import MultiModeResult from './MultiModeResult';
+
+interface Props {
+  difficulty: Difficulty;
+  onExit: () => void;
+}
+
+export default function MultiModeGame({ difficulty, onExit }: Props) {
+  const initialTime = MULTI_MODE_INITIAL_TIME[difficulty];
+
+  const [globalTimeLeft, setGlobalTimeLeft] = useState(initialTime);
+  const [isGameRunning, setIsGameRunning] = useState(true);
+  const [circlesCleared, setCirclesCleared] = useState(0);
+  const [scores, setScores] = useState<ScoringResult[]>([]);
+  const [autoAdvancing, setAutoAdvancing] = useState(false);
+  const [gameResult, setGameResult] = useState<import('./MultiModeResult').MultiModeGameResult | null>(null);
+
+  // stale closure 回避用 ref
+  const globalTimeLeftRef = useRef(globalTimeLeft);
+  const scoresRef = useRef(scores);
+  const circlesClearedRef = useRef(circlesCleared);
+  const gameEndedRef = useRef(false);
+
+  useEffect(() => { globalTimeLeftRef.current = globalTimeLeft; }, [globalTimeLeft]);
+  useEffect(() => { scoresRef.current = scores; }, [scores]);
+  useEffect(() => { circlesClearedRef.current = circlesCleared; }, [circlesCleared]);
+
+  // 1枚クリア時のスコアコールバック（useMagicCircle に渡す）
+  const handleCircleScore = useCallback((result: ScoringResult) => {
+    setScores(prev => [...prev, result]);
+    setCirclesCleared(prev => prev + 1);
+    // クリアボーナス加算（初期時間を上限）
+    setGlobalTimeLeft(prev => Math.min(prev + MULTI_MODE_BONUS_TIME, initialTime));
+    setAutoAdvancing(true);
+  }, [initialTime]);
+
+  const {
+    canvasRef, canvasSize,
+    timeLeft, isActive, showResult, scoreResult, userPath,
+    handleNext, handleReset, handleEvaluate, changeDifficulty,
+    onPointerDown, onPointerMove, onPointerUp,
+    isReplaying, patternName, getRankColor,
+  } = useMagicCircle(handleCircleScore, () => {});
+
+  // 難易度を同期（generateRandomPattern が正しい難易度でパターンを生成するよう）
+  useEffect(() => {
+    changeDifficulty(difficulty);
+  }, [difficulty, changeDifficulty]);
+
+  // 結果表示後に自動的に次の魔法陣へ
+  useEffect(() => {
+    if (!autoAdvancing) return;
+    const timer = setTimeout(() => {
+      handleNext();
+      setAutoAdvancing(false);
+    }, MULTI_MODE_RESULT_DISPLAY_MS);
+    return () => clearTimeout(timer);
+  }, [autoAdvancing, handleNext]);
+
+  // 1枚ごとのタイムアウト → 自動評価または自動スキップ
+  useEffect(() => {
+    if (timeLeft > 0 || isActive || showResult || !isGameRunning || autoAdvancing) return;
+    const timer = setTimeout(() => {
+      if (userPath.length > 0) {
+        handleEvaluate(); // onScore → handleCircleScore → autoAdvancing
+      } else {
+        handleNext(); // 何も描かなかった場合はスキップ
+      }
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [timeLeft, isActive, showResult, isGameRunning, autoAdvancing, userPath.length, handleEvaluate, handleNext]);
+
+  // グローバルタイマー
+  useEffect(() => {
+    if (!isGameRunning) return;
+    const interval = setInterval(() => {
+      setGlobalTimeLeft(prev => {
+        if (prev <= 1) {
+          setIsGameRunning(false);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isGameRunning]);
+
+  // グローバルタイマーが 0 → ゲーム終了
+  useEffect(() => {
+    if (!isGameRunning && globalTimeLeft === 0 && !gameEndedRef.current) {
+      gameEndedRef.current = true;
+      endGame(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isGameRunning, globalTimeLeft]);
+
+  const endGame = useCallback((timeLeftOnEnd: number) => {
+    const currentScores = scoresRef.current;
+    const avgScore =
+      currentScores.length > 0
+        ? currentScores.reduce((sum, r) => sum + r.score, 0) / currentScores.length
+        : 0;
+    setGameResult({
+      circlesCleared: circlesClearedRef.current,
+      scores: currentScores,
+      avgScore,
+      overallRank: calcOverallRank(avgScore),
+      timeLeftOnEnd,
+      difficulty,
+    });
+  }, [difficulty]);
+
+  const handleEndSession = useCallback(() => {
+    if (gameEndedRef.current) return;
+    gameEndedRef.current = true;
+    setIsGameRunning(false);
+    endGame(globalTimeLeftRef.current);
+  }, [endGame]);
+
+  if (gameResult) {
+    return <MultiModeResult result={gameResult} onExit={onExit} />;
+  }
+
+  const timerPercent = (globalTimeLeft / initialTime) * 100;
+  const timerColor =
+    timerPercent > 50 ? '#76ff03' : timerPercent > 25 ? '#ff9100' : '#ff4081';
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      {/* グローバルタイマー HUD */}
+      <div className="w-full max-w-[350px]">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-sm font-bold tabular-nums" style={{ color: timerColor }}>
+            ⏱ {globalTimeLeft}s
+          </span>
+          <span className="text-sm font-bold" style={{ color: '#00e5ff' }}>
+            ✅ {circlesCleared}枚
+          </span>
+          <button
+            onClick={handleEndSession}
+            className="text-xs px-3 py-1 rounded-md border font-bold transition-colors hover:bg-gray-700"
+            style={{ borderColor: '#ff4081', color: '#ff4081' }}
+          >
+            終了
+          </button>
+        </div>
+        <div className="h-2 rounded-full overflow-hidden" style={{ background: '#1a1a2e' }}>
+          <div
+            className="h-full rounded-full transition-all duration-1000"
+            style={{ width: `${timerPercent}%`, background: timerColor }}
+          />
+        </div>
+      </div>
+
+      {/* パターン名 */}
+      <div className="text-sm font-bold" style={{ color: '#7c4dff' }}>
+        {patternName || '準備中...'}
+      </div>
+
+      {/* キャンバス */}
+      <div
+        className="relative w-[350px] max-w-full"
+        style={{ touchAction: 'none' }}
+      >
+        <canvas
+          ref={canvasRef}
+          width={canvasSize}
+          height={canvasSize}
+          className="rounded-lg border-2 border-gray-700 w-full h-auto touch-none"
+          style={{
+            background: '#0a0a14',
+            display: 'block',
+            pointerEvents: isReplaying || autoAdvancing ? 'none' : 'auto',
+            touchAction: 'none',
+          }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerLeave={onPointerUp}
+        />
+
+        {/* 1枚クリア時の結果オーバーレイ（自動遷移） */}
+        {showResult && scoreResult && (
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-lg"
+            style={{ background: 'rgba(13,13,26,0.93)' }}
+          >
+            <div
+              className="text-7xl font-bold"
+              style={{ color: getRankColor(scoreResult.rank) }}
+            >
+              {scoreResult.rank}
+            </div>
+            <div className="text-3xl font-bold text-white">{scoreResult.score}点</div>
+            <div className="text-sm" style={{ color: '#76ff03' }}>
+              +{MULTI_MODE_BONUS_TIME}秒 ボーナス
+            </div>
+            <div className="text-xs text-gray-400 animate-pulse mt-1">
+              次の魔法陣へ...
+            </div>
+          </div>
+        )}
+
+        {/* グローバルタイマー終了オーバーレイ */}
+        {!isGameRunning && globalTimeLeft === 0 && !gameResult && (
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center rounded-lg"
+            style={{ background: 'rgba(13,13,26,0.93)' }}
+          >
+            <div className="text-2xl font-bold" style={{ color: '#ff4081' }}>
+              ⏰ 時間終了！
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* アクションボタン */}
+      <div className="flex gap-3">
+        <button
+          onClick={handleEvaluate}
+          disabled={showResult || autoAdvancing || isReplaying}
+          className="cursor-pointer rounded-md px-6 py-2 font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-80"
+          style={{ background: 'linear-gradient(135deg, #00e5ff, #7c4dff)' }}
+        >
+          詠唱完了！
+        </button>
+        <button
+          onClick={handleReset}
+          disabled={autoAdvancing}
+          className="cursor-pointer rounded-md border-2 border-gray-600 px-6 py-2 font-bold transition-colors hover:bg-gray-800 disabled:opacity-40"
+        >
+          リセット
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MultiModeResult.tsx
+++ b/src/components/MultiModeResult.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { tryUnlock, isComboModeUnlocked } from '@/lib/unlocks';
+import { tryUnlock, isComboModeUnlocked, type UnlockInfo } from '@/lib/unlocks';
 import UnlockModal from './UnlockModal';
 import type { ScoringResult } from '@/lib/scoring';
 import type { Difficulty } from '@/lib/patterns';
@@ -28,15 +28,15 @@ const RANK_COLORS: Record<string, string> = {
 };
 
 export default function MultiModeResult({ result, onExit }: Props) {
-  const [showUnlock, setShowUnlock] = useState(false);
+  const [unlockInfo, setUnlockInfo] = useState<UnlockInfo | null>(null);
   const checkedRef = useRef(false);
 
   useEffect(() => {
     if (checkedRef.current) return;
     checkedRef.current = true;
     if (!isComboModeUnlocked()) {
-      const { newlyUnlocked } = tryUnlock(result.timeLeftOnEnd, result.overallRank);
-      if (newlyUnlocked) setShowUnlock(true);
+      const { newlyUnlocked, info } = tryUnlock(result.timeLeftOnEnd, result.overallRank);
+      if (newlyUnlocked && info) setUnlockInfo(info);
     }
   }, [result.timeLeftOnEnd, result.overallRank]);
 
@@ -44,13 +44,14 @@ export default function MultiModeResult({ result, onExit }: Props) {
   const totalScore = result.scores.reduce((s, r) => s + r.score, 0);
   const isQualified =
     result.timeLeftOnEnd >= 1 && (result.overallRank === 'S' || result.overallRank === 'A');
-  const qualifyCount = typeof window !== 'undefined'
-    ? parseInt(localStorage.getItem('arcane_multi_qualify_count') ?? '0', 10)
-    : 0;
+  const qualifyCount =
+    typeof window !== 'undefined'
+      ? parseInt(localStorage.getItem('arcane_multi_qualify_count') ?? '0', 10)
+      : 0;
 
   return (
     <>
-      {showUnlock && <UnlockModal onClose={() => setShowUnlock(false)} />}
+      {unlockInfo && <UnlockModal unlock={unlockInfo} onClose={() => setUnlockInfo(null)} />}
 
       <div className="flex flex-col items-center gap-5 p-6 max-w-sm w-full">
         <h2 className="text-lg font-bold" style={{ color: '#7c4dff' }}>⚡ マルチモード 結果</h2>
@@ -66,17 +67,12 @@ export default function MultiModeResult({ result, onExit }: Props) {
           <Row label="クリア枚数" value={`${result.circlesCleared}枚`} />
           <Row label="平均スコア" value={`${Math.round(result.avgScore)}点`} />
           <Row label="合計スコア" value={`${totalScore}点`} />
-          <Row
-            label="難易度"
-            value={result.difficulty.toUpperCase()}
-            valueColor="#00e5ff"
-          />
+          <Row label="難易度" value={result.difficulty.toUpperCase()} valueColor="#00e5ff" />
           {result.timeLeftOnEnd > 0 && (
             <Row label="残り時間" value={`${result.timeLeftOnEnd}秒`} valueColor="#76ff03" />
           )}
         </div>
 
-        {/* アンロック進捗ヒント */}
         {!isComboModeUnlocked() && isQualified && (
           <p className="text-sm text-center px-2" style={{ color: '#ffd700' }}>
             ✨ 条件クリア！（{Math.min(qualifyCount, 3)} / 3 回達成）
@@ -88,7 +84,7 @@ export default function MultiModeResult({ result, onExit }: Props) {
           className="w-full px-8 py-3 rounded-lg font-bold text-black transition-transform hover:scale-105 active:scale-95"
           style={{ background: 'linear-gradient(135deg, #7c4dff, #00e5ff)' }}
         >
-          モード選択に戻る
+          ホームに戻る
         </button>
       </div>
     </>

--- a/src/components/MultiModeResult.tsx
+++ b/src/components/MultiModeResult.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { tryUnlock, isComboModeUnlocked } from '@/lib/unlocks';
+import UnlockModal from './UnlockModal';
+import type { ScoringResult } from '@/lib/scoring';
+import type { Difficulty } from '@/lib/patterns';
+
+export interface MultiModeGameResult {
+  circlesCleared: number;
+  scores: ScoringResult[];
+  avgScore: number;
+  overallRank: string;
+  timeLeftOnEnd: number;
+  difficulty: Difficulty;
+}
+
+interface Props {
+  result: MultiModeGameResult;
+  onExit: () => void;
+}
+
+const RANK_COLORS: Record<string, string> = {
+  S: '#ffd700',
+  A: '#00e5ff',
+  B: '#76ff03',
+  C: '#aaaaaa',
+};
+
+export default function MultiModeResult({ result, onExit }: Props) {
+  const [showUnlock, setShowUnlock] = useState(false);
+  const checkedRef = useRef(false);
+
+  useEffect(() => {
+    if (checkedRef.current) return;
+    checkedRef.current = true;
+    if (!isComboModeUnlocked()) {
+      const { newlyUnlocked } = tryUnlock(result.timeLeftOnEnd, result.overallRank);
+      if (newlyUnlocked) setShowUnlock(true);
+    }
+  }, [result.timeLeftOnEnd, result.overallRank]);
+
+  const rankColor = RANK_COLORS[result.overallRank] ?? '#aaaaaa';
+  const totalScore = result.scores.reduce((s, r) => s + r.score, 0);
+  const isQualified =
+    result.timeLeftOnEnd >= 1 && (result.overallRank === 'S' || result.overallRank === 'A');
+  const qualifyCount = typeof window !== 'undefined'
+    ? parseInt(localStorage.getItem('arcane_multi_qualify_count') ?? '0', 10)
+    : 0;
+
+  return (
+    <>
+      {showUnlock && <UnlockModal onClose={() => setShowUnlock(false)} />}
+
+      <div className="flex flex-col items-center gap-5 p-6 max-w-sm w-full">
+        <h2 className="text-lg font-bold" style={{ color: '#7c4dff' }}>⚡ マルチモード 結果</h2>
+
+        <div className="text-8xl font-bold" style={{ color: rankColor }}>
+          {result.overallRank}
+        </div>
+
+        <div
+          className="w-full rounded-xl border p-4 space-y-3"
+          style={{ borderColor: 'rgba(0,229,255,0.2)', background: 'rgba(0,229,255,0.03)' }}
+        >
+          <Row label="クリア枚数" value={`${result.circlesCleared}枚`} />
+          <Row label="平均スコア" value={`${Math.round(result.avgScore)}点`} />
+          <Row label="合計スコア" value={`${totalScore}点`} />
+          <Row
+            label="難易度"
+            value={result.difficulty.toUpperCase()}
+            valueColor="#00e5ff"
+          />
+          {result.timeLeftOnEnd > 0 && (
+            <Row label="残り時間" value={`${result.timeLeftOnEnd}秒`} valueColor="#76ff03" />
+          )}
+        </div>
+
+        {/* アンロック進捗ヒント */}
+        {!isComboModeUnlocked() && isQualified && (
+          <p className="text-sm text-center px-2" style={{ color: '#ffd700' }}>
+            ✨ 条件クリア！（{Math.min(qualifyCount, 3)} / 3 回達成）
+          </p>
+        )}
+
+        <button
+          onClick={onExit}
+          className="w-full px-8 py-3 rounded-lg font-bold text-black transition-transform hover:scale-105 active:scale-95"
+          style={{ background: 'linear-gradient(135deg, #7c4dff, #00e5ff)' }}
+        >
+          モード選択に戻る
+        </button>
+      </div>
+    </>
+  );
+}
+
+function Row({
+  label,
+  value,
+  valueColor = '#ffffff',
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+}) {
+  return (
+    <div className="flex justify-between items-center">
+      <span className="text-sm text-gray-400">{label}</span>
+      <span className="font-bold" style={{ color: valueColor }}>{value}</span>
+    </div>
+  );
+}

--- a/src/components/MultiModeResult.tsx
+++ b/src/components/MultiModeResult.tsx
@@ -7,12 +7,14 @@ import type { ScoringResult } from '@/lib/scoring';
 import type { Difficulty } from '@/lib/patterns';
 
 export interface MultiModeGameResult {
+  mode: 'multi' | 'combo';
   circlesCleared: number;
   scores: ScoringResult[];
   avgScore: number;
   overallRank: string;
   timeLeftOnEnd: number;
   difficulty: Difficulty;
+  maxCombo: number;
 }
 
 interface Props {
@@ -54,7 +56,9 @@ export default function MultiModeResult({ result, onExit }: Props) {
       {unlockInfo && <UnlockModal unlock={unlockInfo} onClose={() => setUnlockInfo(null)} />}
 
       <div className="flex flex-col items-center gap-5 p-6 max-w-sm w-full">
-        <h2 className="text-lg font-bold" style={{ color: '#7c4dff' }}>⚡ マルチモード 結果</h2>
+        <h2 className="text-lg font-bold" style={{ color: result.mode === 'combo' ? '#ffd700' : '#7c4dff' }}>
+          {result.mode === 'combo' ? '🔥 コンボモード 結果' : '⚡ マルチモード 結果'}
+        </h2>
 
         <div className="text-8xl font-bold" style={{ color: rankColor }}>
           {result.overallRank}
@@ -70,6 +74,9 @@ export default function MultiModeResult({ result, onExit }: Props) {
           <Row label="難易度" value={result.difficulty.toUpperCase()} valueColor="#00e5ff" />
           {result.timeLeftOnEnd > 0 && (
             <Row label="残り時間" value={`${result.timeLeftOnEnd}秒`} valueColor="#76ff03" />
+          )}
+          {result.mode === 'combo' && result.maxCombo > 0 && (
+            <Row label="最大コンボ" value={`${result.maxCombo}連続`} valueColor="#ffd700" />
           )}
         </div>
 

--- a/src/components/UnlockModal.tsx
+++ b/src/components/UnlockModal.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function UnlockModal({ onClose }: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.85)' }}
+    >
+      <div
+        className="relative max-w-sm w-full rounded-2xl border-2 p-8 text-center"
+        style={{
+          background: 'linear-gradient(135deg, #0d0d2a, #1a0a2e)',
+          borderColor: '#ffd700',
+          boxShadow: '0 0 40px rgba(255,215,0,0.3)',
+        }}
+      >
+        <div className="text-6xl mb-4 animate-bounce">✨</div>
+        <h2 className="text-2xl font-bold mb-3" style={{ color: '#ffd700' }}>
+          コンボモード 解放！
+        </h2>
+        <p className="text-gray-300 mb-2 text-sm">
+          制限時間より早く、高精度で3回クリアを達成しました。
+        </p>
+        <p className="text-xs mb-6" style={{ color: '#00e5ff' }}>
+          モード選択画面でコンボモードが選べるようになりました。
+        </p>
+        <button
+          onClick={onClose}
+          className="px-8 py-3 rounded-lg font-bold text-black transition-transform hover:scale-105 active:scale-95"
+          style={{ background: 'linear-gradient(135deg, #ffd700, #ff9100)' }}
+        >
+          解放する！
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UnlockModal.tsx
+++ b/src/components/UnlockModal.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import type { UnlockInfo } from '@/lib/unlocks';
+
 interface Props {
+  unlock: UnlockInfo;
   onClose: () => void;
 }
 
-export default function UnlockModal({ onClose }: Props) {
+export default function UnlockModal({ unlock, onClose }: Props) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -18,22 +21,17 @@ export default function UnlockModal({ onClose }: Props) {
           boxShadow: '0 0 40px rgba(255,215,0,0.3)',
         }}
       >
-        <div className="text-6xl mb-4 animate-bounce">✨</div>
+        <div className="text-6xl mb-4 animate-bounce">{unlock.icon}</div>
         <h2 className="text-2xl font-bold mb-3" style={{ color: '#ffd700' }}>
-          コンボモード 解放！
+          {unlock.title}
         </h2>
-        <p className="text-gray-300 mb-2 text-sm">
-          制限時間より早く、高精度で3回クリアを達成しました。
-        </p>
-        <p className="text-xs mb-6" style={{ color: '#00e5ff' }}>
-          モード選択画面でコンボモードが選べるようになりました。
-        </p>
+        <p className="text-sm text-gray-300 mb-6">{unlock.description}</p>
         <button
           onClick={onClose}
           className="px-8 py-3 rounded-lg font-bold text-black transition-transform hover:scale-105 active:scale-95"
           style={{ background: 'linear-gradient(135deg, #ffd700, #ff9100)' }}
         >
-          解放する！
+          OK！
         </button>
       </div>
     </div>

--- a/src/hooks/useMagicCircle.ts
+++ b/src/hooks/useMagicCircle.ts
@@ -973,6 +973,7 @@ export function useMagicCircle(
       difficulty: historyItem.difficulty,
       difficultyMultiplier: historyItem.difficultyMultiplier,
       damageMultiplier: historyItem.damageMultiplier,
+      createdAt: historyItem.createdAt,
     };
 
     // 履歴データをURL用に圧縮

--- a/src/lib/multiModeConstants.ts
+++ b/src/lib/multiModeConstants.ts
@@ -7,11 +7,14 @@ export const MULTI_MODE_INITIAL_TIME: Record<Difficulty, number> = {
   expert: 30,
 };
 
-/** 1枚クリアごとの追加秒数（初期時間を上限とする） */
 export const MULTI_MODE_BONUS_TIME = 5;
-
-/** スコア表示後、次の魔法陣へ自動遷移するまでの時間 (ms) */
 export const MULTI_MODE_RESULT_DISPLAY_MS = 1800;
+
+/** 連続 A 以上の枚数に基づくコンボ倍率（上限 3.0x） */
+export function getComboMultiplier(consecutiveAPlus: number): number {
+  if (consecutiveAPlus <= 0) return 1.0;
+  return Math.min(1.0 + consecutiveAPlus * 0.5, 3.0);
+}
 
 export function calcOverallRank(avgScore: number): string {
   if (avgScore >= 90) return 'S';

--- a/src/lib/multiModeConstants.ts
+++ b/src/lib/multiModeConstants.ts
@@ -1,0 +1,21 @@
+import type { Difficulty } from './patterns';
+
+export const MULTI_MODE_INITIAL_TIME: Record<Difficulty, number> = {
+  easy: 90,
+  normal: 60,
+  hard: 45,
+  expert: 30,
+};
+
+/** 1枚クリアごとの追加秒数（初期時間を上限とする） */
+export const MULTI_MODE_BONUS_TIME = 5;
+
+/** スコア表示後、次の魔法陣へ自動遷移するまでの時間 (ms) */
+export const MULTI_MODE_RESULT_DISPLAY_MS = 1800;
+
+export function calcOverallRank(avgScore: number): string {
+  if (avgScore >= 90) return 'S';
+  if (avgScore >= 70) return 'A';
+  if (avgScore >= 50) return 'B';
+  return 'C';
+}

--- a/src/lib/unlocks.ts
+++ b/src/lib/unlocks.ts
@@ -1,49 +1,123 @@
+const HISTORY_UNLOCKED_KEY = 'arcane_history_unlocked';
+const MULTI_MODE_UNLOCKED_KEY = 'arcane_multi_mode_unlocked';
+const GRIMOIRE_UNLOCKED_KEY = 'arcane_grimoire_unlocked';
 const MULTI_QUALIFY_KEY = 'arcane_multi_qualify_count';
 const COMBO_UNLOCKED_KEY = 'arcane_combo_unlocked';
 const UNLOCK_THRESHOLD = 3;
 
-export function isComboModeUnlocked(): boolean {
-  if (typeof window === 'undefined') return false;
-  try {
-    return localStorage.getItem(COMBO_UNLOCKED_KEY) === 'true';
-  } catch {
-    return false;
-  }
+// アンロック条件（総プレイ数）
+const HISTORY_THRESHOLD = 1;
+const MULTI_MODE_THRESHOLD = 5;
+const GRIMOIRE_THRESHOLD = 10;
+
+export interface UnlockInfo {
+  key: string;
+  icon: string;
+  title: string;
+  description: string;
 }
+
+const UNLOCK_INFO: Record<string, UnlockInfo> = {
+  history: {
+    key: 'history',
+    icon: '📜',
+    title: '作成履歴 解放！',
+    description: 'これまでに詠唱した魔法陣の履歴を確認できます。メニューから開けます。',
+  },
+  multiMode: {
+    key: 'multiMode',
+    icon: '⚡',
+    title: 'マルチモード 解放！',
+    description: '時間制限内に何枚もの魔法陣を連続詠唱するモードが解放されました。メニューから選択できます。',
+  },
+  grimoire: {
+    key: 'grimoire',
+    icon: '📖',
+    title: '魔導書 解放！',
+    description: '全ての魔法陣パターンを閲覧できる魔導書が解放されました。メニューから開けます。',
+  },
+  comboMode: {
+    key: 'comboMode',
+    icon: '🔥',
+    title: 'コンボモード 解放！',
+    description: '制限時間より早く、高精度でクリアを3回達成！コンボ倍率ありのモードが解放されました。',
+  },
+};
+
+function get(key: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try { return localStorage.getItem(key) === 'true'; } catch { return false; }
+}
+
+function set(key: string): void {
+  try { localStorage.setItem(key, 'true'); } catch { /* ignore */ }
+}
+
+export function isHistoryUnlocked(): boolean { return get(HISTORY_UNLOCKED_KEY); }
+export function isMultiModeUnlocked(): boolean { return get(MULTI_MODE_UNLOCKED_KEY); }
+export function isGrimoireUnlocked(): boolean { return get(GRIMOIRE_UNLOCKED_KEY); }
+export function isComboModeUnlocked(): boolean { return get(COMBO_UNLOCKED_KEY); }
 
 export function getQualifyCount(): number {
   if (typeof window === 'undefined') return 0;
-  try {
-    return parseInt(localStorage.getItem(MULTI_QUALIFY_KEY) ?? '0', 10);
-  } catch {
-    return 0;
-  }
+  try { return parseInt(localStorage.getItem(MULTI_QUALIFY_KEY) ?? '0', 10); } catch { return 0; }
 }
 
-/** セッション終了時にアンロック判定を行う。新規解放時は newlyUnlocked = true を返す */
+/** 現在のアンロック状態を全て返す */
+export function getAllUnlockStatus() {
+  return {
+    history: isHistoryUnlocked(),
+    multiMode: isMultiModeUnlocked(),
+    grimoire: isGrimoireUnlocked(),
+    comboMode: isComboModeUnlocked(),
+  };
+}
+
+/** プレイ回数に基づくアンロックチェック。新規解放されたものを返す */
+export function checkPlayBasedUnlocks(totalPlays: number): UnlockInfo[] {
+  if (typeof window === 'undefined') return [];
+  const results: UnlockInfo[] = [];
+
+  if (totalPlays >= HISTORY_THRESHOLD && !isHistoryUnlocked()) {
+    set(HISTORY_UNLOCKED_KEY);
+    results.push(UNLOCK_INFO.history);
+  }
+  if (totalPlays >= MULTI_MODE_THRESHOLD && !isMultiModeUnlocked()) {
+    set(MULTI_MODE_UNLOCKED_KEY);
+    results.push(UNLOCK_INFO.multiMode);
+  }
+  if (totalPlays >= GRIMOIRE_THRESHOLD && !isGrimoireUnlocked()) {
+    set(GRIMOIRE_UNLOCKED_KEY);
+    results.push(UNLOCK_INFO.grimoire);
+  }
+
+  return results;
+}
+
+/** マルチモードセッション終了時のコンボモードアンロック判定 */
 export function tryUnlock(
   timeLeftOnEnd: number,
   overallRank: string,
-): { qualified: boolean; newlyUnlocked: boolean; count: number } {
-  if (typeof window === 'undefined') return { qualified: false, newlyUnlocked: false, count: 0 };
+): { qualified: boolean; newlyUnlocked: boolean; count: number; info: UnlockInfo | null } {
+  if (typeof window === 'undefined') {
+    return { qualified: false, newlyUnlocked: false, count: 0, info: null };
+  }
 
   const qualified = timeLeftOnEnd >= 1 && (overallRank === 'S' || overallRank === 'A');
-  if (!qualified) return { qualified: false, newlyUnlocked: false, count: getQualifyCount() };
+  if (!qualified) {
+    return { qualified: false, newlyUnlocked: false, count: getQualifyCount(), info: null };
+  }
 
   const alreadyUnlocked = isComboModeUnlocked();
   const currentCount = getQualifyCount();
   const newCount = currentCount + 1;
 
-  try {
-    localStorage.setItem(MULTI_QUALIFY_KEY, String(newCount));
-  } catch { /* ignore */ }
+  try { localStorage.setItem(MULTI_QUALIFY_KEY, String(newCount)); } catch { /* ignore */ }
 
   if (!alreadyUnlocked && newCount >= UNLOCK_THRESHOLD) {
-    try {
-      localStorage.setItem(COMBO_UNLOCKED_KEY, 'true');
-    } catch { /* ignore */ }
-    return { qualified: true, newlyUnlocked: true, count: newCount };
+    set(COMBO_UNLOCKED_KEY);
+    return { qualified: true, newlyUnlocked: true, count: newCount, info: UNLOCK_INFO.comboMode };
   }
 
-  return { qualified: true, newlyUnlocked: false, count: newCount };
+  return { qualified: true, newlyUnlocked: false, count: newCount, info: null };
 }

--- a/src/lib/unlocks.ts
+++ b/src/lib/unlocks.ts
@@ -1,0 +1,49 @@
+const MULTI_QUALIFY_KEY = 'arcane_multi_qualify_count';
+const COMBO_UNLOCKED_KEY = 'arcane_combo_unlocked';
+const UNLOCK_THRESHOLD = 3;
+
+export function isComboModeUnlocked(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(COMBO_UNLOCKED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function getQualifyCount(): number {
+  if (typeof window === 'undefined') return 0;
+  try {
+    return parseInt(localStorage.getItem(MULTI_QUALIFY_KEY) ?? '0', 10);
+  } catch {
+    return 0;
+  }
+}
+
+/** セッション終了時にアンロック判定を行う。新規解放時は newlyUnlocked = true を返す */
+export function tryUnlock(
+  timeLeftOnEnd: number,
+  overallRank: string,
+): { qualified: boolean; newlyUnlocked: boolean; count: number } {
+  if (typeof window === 'undefined') return { qualified: false, newlyUnlocked: false, count: 0 };
+
+  const qualified = timeLeftOnEnd >= 1 && (overallRank === 'S' || overallRank === 'A');
+  if (!qualified) return { qualified: false, newlyUnlocked: false, count: getQualifyCount() };
+
+  const alreadyUnlocked = isComboModeUnlocked();
+  const currentCount = getQualifyCount();
+  const newCount = currentCount + 1;
+
+  try {
+    localStorage.setItem(MULTI_QUALIFY_KEY, String(newCount));
+  } catch { /* ignore */ }
+
+  if (!alreadyUnlocked && newCount >= UNLOCK_THRESHOLD) {
+    try {
+      localStorage.setItem(COMBO_UNLOCKED_KEY, 'true');
+    } catch { /* ignore */ }
+    return { qualified: true, newlyUnlocked: true, count: newCount };
+  }
+
+  return { qualified: true, newlyUnlocked: false, count: newCount };
+}


### PR DESCRIPTION
## 概要

1プレイで複数魔法陣を連続詠唱する**マルチモード**と、やり込み要素の**コンボモードアンロック機能**を実装。

## 追加機能

### ⚡ マルチモード
- 時間制限内に何枚でも魔法陣を連続詠唱
- **難易度別の制限時間**:
  - EASY: 90秒 / NORMAL: 60秒 / HARD: 45秒 / EXPERT: 30秒
- **クリアボーナス**: 1枚クリアごとに +5秒（初期時間を上限）
- **1枚ごとのタイムアウト**: 時間切れ時は自動評価・自動スキップ
- 「終了」ボタンで任意タイミングでセッション終了
- 結果画面: クリア枚数・平均スコア・合計スコア・総合ランク表示

### 🔒 コンボモードアンロック（やり込み要素）
- 初期状態では `???` として非表示扱いの施錠表示
- **解放条件**: マルチモードで「制限時間より1秒以上早く終了 + Aランク以上」を3回達成
- 達成時にアンロックモーダルを表示
- 解放後はモード選択画面に「🔥 コンボモード」として表示

### 🎮 モード選択画面
- ホーム画面にモード選択を追加
- シングルモード → 既存の1枚詠唱ゲーム
- マルチモード → 難易度選択後にゲーム開始
- コンボモード → アンロック前は施錠表示、達成回数をヒント表示

## 新規ファイル
| ファイル | 役割 |
|---|---|
| `src/lib/unlocks.ts` | アンロック状態管理（localStorage） |
| `src/lib/multiModeConstants.ts` | 難易度別タイマー・ボーナス定数 |
| `src/components/ModeSelectScreen.tsx` | モード選択・難易度選択UI |
| `src/components/MultiModeGame.tsx` | マルチモードゲーム本体 |
| `src/components/MultiModeResult.tsx` | 結果画面・アンロック判定 |
| `src/components/UnlockModal.tsx` | コンボ解放通知モーダル |

## 変更ファイル
- `src/app/page.tsx` — モード選択フロー追加、再編集URLは直接シングルモードへ

## テスト計画
- [ ] モード選択画面が表示されること
- [ ] シングルモードが既存動作のまま動くこと
- [ ] マルチモードで難易度選択後にゲームが開始されること
- [ ] 1枚クリアで +5秒ボーナスが加算されること（初期時間を超えないこと）
- [ ] タイムアウト時に自動評価・自動スキップすること
- [ ] 「終了」ボタンで結果画面に遷移すること
- [ ] アンロック条件3回達成でUnlockModalが表示されること
- [ ] 再編集URLからはシングルモードに直接遷移すること

https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau

---
_Generated by [Claude Code](https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau)_