### PR TITLE
fix: マルチ/コンボモードに☰メニュー追加・モード選択をボタングリッド化

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,6 +139,8 @@ function HomeContent() {
           mode={screen.type}
           difficulty={screen.difficulty}
           onExit={handleMultiExit}
+          unlocks={{ multiMode: unlocks.multiMode, comboMode: unlocks.comboMode }}
+          onSwitchMode={handleSwitchMode}
         />
       )}
     </div>

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -139,26 +139,31 @@ export default function MagicCircleCanvas({
             className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
             style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
           >
-            {/* マルチモード（アンロック済みのみ） */}
-            {unlocks?.multiMode && (
-              <button
-                onClick={() => { onSwitchMode?.('multi', difficulty); setShowMenu(false); }}
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-                style={{ color: '#7c4dff' }}
-              >
-                ⚡ マルチモード
-              </button>
-            )}
-
-            {/* コンボモード（アンロック済みのみ） */}
-            {unlocks?.comboMode && (
-              <button
-                onClick={() => { onSwitchMode?.('combo', difficulty); setShowMenu(false); }}
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-                style={{ color: '#ffd700' }}
-              >
-                🔥 コンボモード
-              </button>
+            {/* モード変更（アンロック済みのみ） */}
+            {(unlocks?.multiMode || unlocks?.comboMode) && (
+              <div className="px-3 py-2">
+                <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
+                <div className="flex flex-wrap gap-1">
+                  {unlocks?.multiMode && (
+                    <button
+                      onClick={() => { onSwitchMode?.('multi', difficulty); setShowMenu(false); }}
+                      className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
+                      style={{ borderColor: '#7c4dff', borderWidth: 2, borderStyle: 'solid', color: '#7c4dff', background: 'transparent' }}
+                    >
+                      ⚡ マルチ
+                    </button>
+                  )}
+                  {unlocks?.comboMode && (
+                    <button
+                      onClick={() => { onSwitchMode?.('combo', difficulty); setShowMenu(false); }}
+                      className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
+                      style={{ borderColor: '#ffd700', borderWidth: 2, borderStyle: 'solid', color: '#ffd700', background: 'transparent' }}
+                    >
+                      🔥 コンボ
+                    </button>
+                  )}
+                </div>
+              </div>
             )}
 
             {/* 魔導書（アンロック済みのみ） */}

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -17,9 +17,11 @@ interface Props {
   mode: 'multi' | 'combo';
   difficulty: Difficulty;
   onExit: () => void;
+  unlocks?: { multiMode?: boolean; comboMode?: boolean };
+  onSwitchMode?: (mode: 'multi' | 'combo', difficulty: Difficulty) => void;
 }
 
-export default function MultiModeGame({ mode, difficulty, onExit }: Props) {
+export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwitchMode }: Props) {
   const initialTime = MULTI_MODE_INITIAL_TIME[difficulty];
   const isCombo = mode === 'combo';
 
@@ -30,6 +32,7 @@ export default function MultiModeGame({ mode, difficulty, onExit }: Props) {
   const [autoAdvancing, setAutoAdvancing] = useState(false);
   const [comboCount, setComboCount] = useState(0);
   const [comboBreak, setComboBreak] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
   const [gameResult, setGameResult] = useState<import('./MultiModeResult').MultiModeGameResult | null>(null);
 
   const globalTimeLeftRef = useRef(globalTimeLeft);
@@ -170,6 +173,70 @@ export default function MultiModeGame({ mode, difficulty, onExit }: Props) {
 
   return (
     <div className="flex flex-col items-center gap-4 p-4">
+      {/* ☰ メニューボタン */}
+      <button
+        onClick={() => setShowMenu(v => !v)}
+        className="absolute right-4 top-4 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 text-xl font-bold"
+        style={{ borderColor: 'rgba(0,229,255,0.5)', color: '#00e5ff', background: 'rgba(10,10,20,0.8)' }}
+        aria-label="メニュー"
+      >
+        ☰
+      </button>
+
+      {/* メニューパネル */}
+      {showMenu && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
+          <div
+            className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
+            style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
+          >
+            {/* モード変更 */}
+            <div className="px-3 py-2">
+              <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
+              <div className="flex flex-wrap gap-1">
+                {/* シングルモードに戻る */}
+                <button
+                  onClick={() => { onExit(); setShowMenu(false); }}
+                  className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
+                  style={{ borderColor: '#00e5ff', borderWidth: 2, borderStyle: 'solid', color: '#00e5ff', background: 'transparent' }}
+                >
+                  ⚔️ シングル
+                </button>
+                {/* マルチ */}
+                {(unlocks?.multiMode ?? true) && (
+                  <button
+                    onClick={() => { if (mode !== 'multi') { onSwitchMode?.('multi', difficulty); } setShowMenu(false); }}
+                    className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${mode === 'multi' ? 'scale-105' : 'opacity-60 hover:opacity-100'}`}
+                    style={{
+                      borderColor: '#7c4dff', borderWidth: 2, borderStyle: 'solid',
+                      color: mode === 'multi' ? '#7c4dff' : '#999',
+                      background: mode === 'multi' ? '#7c4dff18' : 'transparent',
+                    }}
+                  >
+                    ⚡ マルチ
+                  </button>
+                )}
+                {/* コンボ */}
+                {unlocks?.comboMode && (
+                  <button
+                    onClick={() => { if (mode !== 'combo') { onSwitchMode?.('combo', difficulty); } setShowMenu(false); }}
+                    className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${mode === 'combo' ? 'scale-105' : 'opacity-60 hover:opacity-100'}`}
+                    style={{
+                      borderColor: '#ffd700', borderWidth: 2, borderStyle: 'solid',
+                      color: mode === 'combo' ? '#ffd700' : '#999',
+                      background: mode === 'combo' ? '#ffd70018' : 'transparent',
+                    }}
+                  >
+                    🔥 コンボ
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
       {/* グローバルタイマー HUD */}
       <div className="w-full max-w-[350px]">
         <div className="flex items-center justify-between mb-1">


### PR DESCRIPTION
## 概要

マルチ/コンボモードでシングルモードへすぐ戻れない問題を修正。メニューのモード選択UIをレベル変更と同じボタングリッド形式に統一。

## 変更内容

- **MultiModeGame**: 右上に☰メニューボタンを追加
  - 「シングル / マルチ / コンボ」をボタングリッドで表示（レベル変更と同形式）
  - 現在のモードをハイライト表示
  - シングルモードへ即時戻り可能
  - マルチ⇔コンボ間もメニューから直接切替可能
- **MagicCircleCanvas**: モード選択をリスト形式→ボタングリッド形式に変更

## テスト計画
- [ ] マルチモード中に☰ボタンが右上に表示されること
- [ ] メニューから「シングル」を押すとシングルモードに戻れること
- [ ] メニューのモード選択がレベル変更と同じスタイルで表示されること
- [ ] 現在のモードがハイライトされること

https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau

---
_Generated by [Claude Code](https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau)_