### PR TITLE
refactor: ☰メニューをGameMenuコンポーネントに共通化・バグ修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,7 +139,7 @@ function HomeContent() {
           mode={screen.type}
           difficulty={screen.difficulty}
           onExit={handleMultiExit}
-          unlocks={{ multiMode: unlocks.multiMode, comboMode: unlocks.comboMode }}
+          unlocks={{ history: unlocks.history, grimoire: unlocks.grimoire, multiMode: unlocks.multiMode, comboMode: unlocks.comboMode }}
           onSwitchMode={handleSwitchMode}
         />
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,7 +139,7 @@ function HomeContent() {
           mode={screen.type}
           difficulty={screen.difficulty}
           onExit={handleMultiExit}
-          unlocks={{ history: unlocks.history, grimoire: unlocks.grimoire, multiMode: unlocks.multiMode, comboMode: unlocks.comboMode }}
+          unlocks={unlocks}
           onSwitchMode={handleSwitchMode}
         />
       )}

--- a/src/components/GameMenu.tsx
+++ b/src/components/GameMenu.tsx
@@ -3,10 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { Difficulty } from '@/lib/patterns';
-
-const DIFFICULTY_LABELS: Record<Difficulty, string> = {
-  easy: '0.8', normal: '1', hard: '1.3', expert: '1.6',
-};
+import { DIFFICULTY_MULTIPLIER } from '@/lib/patterns';
 
 const DIFFICULTY_COLORS: Record<Difficulty, string> = {
   easy: '#76ff03', normal: '#00e5ff', hard: '#ff9100', expert: '#ff4081',
@@ -69,8 +66,8 @@ export default function GameMenu({
             className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
             style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
           >
-            {/* モード変更（いずれかアンロック済みなら表示） */}
-            {(unlocks?.multiMode || unlocks?.comboMode) && (
+            {/* モード変更（アンロック済みまたは現在マルチ/コンボモードなら表示） */}
+            {(unlocks?.multiMode || unlocks?.comboMode || currentMode !== 'single') && (
               <div className="px-3 py-2">
                 <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
                 <div className="flex flex-wrap gap-1">
@@ -130,7 +127,7 @@ export default function GameMenu({
                     }}
                   >
                     {d.toUpperCase()}
-                    <span className="ml-1 opacity-75">(×{DIFFICULTY_LABELS[d]})</span>
+                    <span className="ml-1 opacity-75">(×{DIFFICULTY_MULTIPLIER[d]})</span>
                   </button>
                 ))}
               </div>

--- a/src/components/GameMenu.tsx
+++ b/src/components/GameMenu.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Difficulty } from '@/lib/patterns';
+
+const DIFFICULTY_LABELS: Record<Difficulty, string> = {
+  easy: '0.8', normal: '1', hard: '1.3', expert: '1.6',
+};
+
+const DIFFICULTY_COLORS: Record<Difficulty, string> = {
+  easy: '#76ff03', normal: '#00e5ff', hard: '#ff9100', expert: '#ff4081',
+};
+
+export interface VoiceState {
+  isListening: boolean;
+  isMicAccessible: boolean | null;
+}
+
+export interface UnlockState {
+  history?: boolean;
+  multiMode?: boolean;
+  grimoire?: boolean;
+  comboMode?: boolean;
+}
+
+interface GameMenuProps {
+  currentMode: 'single' | 'multi' | 'combo';
+  difficulty: Difficulty;
+  unlocks?: UnlockState;
+  onSwitchMode: (mode: 'single' | 'multi' | 'combo', difficulty: Difficulty) => void;
+  onChangeDifficulty: (d: Difficulty) => void;
+  onShowHistory?: () => void;
+  voiceState?: VoiceState | null;
+  onVoiceToggle?: () => void;
+  onShowHelp?: () => void;
+}
+
+export default function GameMenu({
+  currentMode,
+  difficulty,
+  unlocks,
+  onSwitchMode,
+  onChangeDifficulty,
+  onShowHistory,
+  voiceState,
+  onVoiceToggle,
+  onShowHelp,
+}: GameMenuProps) {
+  const router = useRouter();
+  const [showMenu, setShowMenu] = useState(false);
+  const close = () => setShowMenu(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setShowMenu(v => !v)}
+        className="absolute right-4 top-4 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 text-xl font-bold"
+        style={{ borderColor: 'rgba(0,229,255,0.5)', color: '#00e5ff', background: 'rgba(10,10,20,0.8)' }}
+        aria-label="メニュー"
+      >
+        ☰
+      </button>
+
+      {showMenu && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={close} />
+          <div
+            className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
+            style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
+          >
+            {/* モード変更（いずれかアンロック済みなら表示） */}
+            {(unlocks?.multiMode || unlocks?.comboMode) && (
+              <div className="px-3 py-2">
+                <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
+                <div className="flex flex-wrap gap-1">
+                  <ModeBtn
+                    label="シングル"
+                    isActive={currentMode === 'single'}
+                    color="#00e5ff"
+                    onClick={() => { onSwitchMode('single', difficulty); close(); }}
+                  />
+                  {unlocks?.multiMode && (
+                    <ModeBtn
+                      label="⚡ マルチ"
+                      isActive={currentMode === 'multi'}
+                      color="#7c4dff"
+                      onClick={() => { onSwitchMode('multi', difficulty); close(); }}
+                    />
+                  )}
+                  {unlocks?.comboMode && (
+                    <ModeBtn
+                      label="🔥 コンボ"
+                      isActive={currentMode === 'combo'}
+                      color="#ffd700"
+                      onClick={() => { onSwitchMode('combo', difficulty); close(); }}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* 魔導書 */}
+            {unlocks?.grimoire && (
+              <MenuItem icon="📖" label="魔導書" onClick={() => { router.push('/grimoire'); close(); }} />
+            )}
+
+            {/* 作成履歴 */}
+            {unlocks?.history && onShowHistory && (
+              <MenuItem icon="📜" label="作成履歴" onClick={() => { onShowHistory(); close(); }} />
+            )}
+
+            {/* レベル変更 */}
+            <div className="px-3 py-2">
+              <div className="mb-2 text-xs font-bold text-gray-500">🎯 レベル変更</div>
+              <div className="flex flex-wrap gap-1">
+                {(['easy', 'normal', 'hard', 'expert'] as Difficulty[]).map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => { onChangeDifficulty(d); close(); }}
+                    className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${
+                      difficulty === d ? 'scale-105' : 'opacity-50 hover:opacity-75'
+                    }`}
+                    style={{
+                      borderColor: DIFFICULTY_COLORS[d],
+                      borderWidth: 2,
+                      borderStyle: 'solid',
+                      color: difficulty === d ? DIFFICULTY_COLORS[d] : '#999',
+                      background: difficulty === d ? `${DIFFICULTY_COLORS[d]}18` : 'transparent',
+                    }}
+                  >
+                    {d.toUpperCase()}
+                    <span className="ml-1 opacity-75">(×{DIFFICULTY_LABELS[d]})</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* 音声入力 */}
+            {onVoiceToggle && (
+              <button
+                onClick={() => { onVoiceToggle(); close(); }}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+                style={{
+                  color: voiceState?.isListening ? '#76ff03'
+                    : voiceState?.isMicAccessible === false ? '#ff4444'
+                    : '#00e5ff',
+                }}
+              >
+                {voiceState?.isListening ? '🎤' : voiceState?.isMicAccessible === false ? '🔇' : '🔊'}
+                {' '}音声入力{voiceState?.isListening ? '（ON）' : '（OFF）'}
+              </button>
+            )}
+
+            {/* アプリ情報 */}
+            <MenuItem icon="ℹ️" label="アプリ情報" onClick={() => { router.push('/app-info'); close(); }} />
+
+            {/* ヘルプ */}
+            {onShowHelp && (
+              <MenuItem icon="❓" label="ヘルプ" onClick={() => { onShowHelp(); close(); }} />
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function ModeBtn({
+  label, isActive, color, onClick,
+}: {
+  label: string; isActive: boolean; color: string; onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={isActive}
+      className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${isActive ? 'scale-105' : 'opacity-60 hover:opacity-100'}`}
+      style={{
+        borderColor: color,
+        borderWidth: 2,
+        borderStyle: 'solid',
+        color: isActive ? color : '#999',
+        background: isActive ? `${color}18` : 'transparent',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function MenuItem({ icon, label, onClick }: { icon: string; label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
+      style={{ color: '#00e5ff' }}
+    >
+      {icon} {label}
+    </button>
+  );
+}

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
 import type { ScoringResult } from '@/lib/scoring';
 import type { Difficulty } from '@/lib/patterns';
-import { DIFFICULTY_MULTIPLIER } from '@/lib/patterns';
 import { useMagicCircle } from '@/hooks/useMagicCircle';
+import GameMenu from './GameMenu';
 import type { MagicCircleData, MagicCircleHistory } from '@/lib/types';
 import HelpModal from './HelpModal';
 import HistoryPanel from './HistoryPanel';
@@ -52,7 +51,6 @@ export default function MagicCircleCanvas({
   /** モード切替コールバック */
   onSwitchMode?: (mode: 'multi' | 'combo', difficulty: Difficulty) => void;
 }) {
-  const router = useRouter();
 
   const {
     canvasRef, canvasSize, isDrawing, userPath,
@@ -72,7 +70,6 @@ export default function MagicCircleCanvas({
     typeof window !== 'undefined' && !localStorage.getItem('tutorialCompleted')
   );
   const [showHistory, setShowHistory] = useState(false);
-  const [showMenu, setShowMenu] = useState(false);
   const [selectedHistory, setSelectedHistory] = useState<MagicCircleHistory | null>(null);
 
   // チュートリアル完了時に localStorage にフラグを保存
@@ -114,6 +111,35 @@ export default function MagicCircleCanvas({
     ? `赤い点から「${patternName}」をなぞってください`
     : '赤い点から魔法陣をなぞってください';
 
+  const handleVoiceToggle = useCallback(async () => {
+    if (voiceActivation) {
+      if (voiceActivation.isListening) {
+        try {
+          await voiceActivation.stopListening();
+          setDebugMsg('🔇 音声検知を停止しました');
+        } catch (err) {
+          console.error('音声検知停止エラー:', err);
+          setDebugMsg('⚠️ 音声検知停止エラー');
+        }
+      } else {
+        try {
+          await voiceActivation.startListening();
+          setDebugMsg('🎤 音声検知を開始しました');
+        } catch (err) {
+          console.error('音声検知開始エラー:', err);
+          setDebugMsg('⚠️ マイクアクセスが拒否または利用できません');
+          setVoiceActivation(null);
+        }
+      }
+    } else {
+      setDebugMsg('⚠️ 音声検知は利用できません（マイクアクセスが必要）');
+    }
+  }, [voiceActivation, setDebugMsg, setVoiceActivation]);
+
+  const handleSwitchModeFromMenu = useCallback((mode: 'single' | 'multi' | 'combo', diff: Difficulty) => {
+    if (mode !== 'single') onSwitchMode?.(mode, diff);
+  }, [onSwitchMode]);
+
   return (
     <div className="flex flex-col items-center gap-4 p-4">
       {showTutorial && (
@@ -121,170 +147,21 @@ export default function MagicCircleCanvas({
       )}
       {showHelp && <HelpModal onClose={() => setShowHelp(false)} />}
 
-      {/* メニューボタン */}
-      <button
-        onClick={() => setShowMenu(v => !v)}
-        className="absolute right-4 top-4 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 text-xl font-bold"
-        style={{ borderColor: 'rgba(0,229,255,0.5)', color: '#00e5ff', background: 'rgba(10,10,20,0.8)' }}
-        aria-label="メニュー"
-      >
-        ☰
-      </button>
+      {/* 共通メニュー */}
+      <GameMenu
+        currentMode="single"
+        difficulty={difficulty}
+        unlocks={unlocks}
+        onSwitchMode={handleSwitchModeFromMenu}
+        onChangeDifficulty={changeDifficulty}
+        onShowHistory={() => setShowHistory(true)}
+        voiceState={voiceActivation}
+        onVoiceToggle={handleVoiceToggle}
+        onShowHelp={() => setShowHelp(true)}
+      />
 
-      {/* メニューパネル */}
-      {showMenu && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
-          <div
-            className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
-            style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
-          >
-            {/* モード変更（アンロック済みのみ） */}
-            {(unlocks?.multiMode || unlocks?.comboMode) && (
-              <div className="px-3 py-2">
-                <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
-                <div className="flex flex-wrap gap-1">
-                  {/* シングル（現在のモード・選択済み） */}
-                  <button
-                    className="rounded-md px-2 py-1 text-xs font-bold transition-all scale-105"
-                    style={{ borderColor: '#00e5ff', borderWidth: 2, borderStyle: 'solid', color: '#00e5ff', background: '#00e5ff18' }}
-                    disabled
-                  >
-                    シングル
-                  </button>
-                  {unlocks?.multiMode && (
-                    <button
-                      onClick={() => { onSwitchMode?.('multi', difficulty); setShowMenu(false); }}
-                      className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
-                      style={{ borderColor: '#7c4dff', borderWidth: 2, borderStyle: 'solid', color: '#999', background: 'transparent' }}
-                    >
-                      ⚡ マルチ
-                    </button>
-                  )}
-                  {unlocks?.comboMode && (
-                    <button
-                      onClick={() => { onSwitchMode?.('combo', difficulty); setShowMenu(false); }}
-                      className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
-                      style={{ borderColor: '#ffd700', borderWidth: 2, borderStyle: 'solid', color: '#999', background: 'transparent' }}
-                    >
-                      🔥 コンボ
-                    </button>
-                  )}
-                </div>
-              </div>
-            )}
 
-            {/* 魔導書（アンロック済みのみ） */}
-            {unlocks?.grimoire && (
-              <button
-                onClick={() => { router.push('/grimoire'); setShowMenu(false); }}
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-                style={{ color: '#00e5ff' }}
-              >
-                📖 魔導書
-              </button>
-            )}
-
-            {/* 作成履歴（アンロック済みのみ） */}
-            {unlocks?.history && (
-              <button
-                onClick={() => { setShowHistory(true); setShowMenu(false); }}
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-                style={{ color: '#00e5ff' }}
-              >
-                📜 作成履歴
-              </button>
-            )}
-
-            {/* レベル変更 */}
-            <div className="px-3 py-2">
-              <div className="mb-2 text-xs font-bold text-gray-500">🎯 レベル変更</div>
-              <div className="flex flex-wrap gap-1">
-                {(['easy', 'normal', 'hard', 'expert'] as Difficulty[]).map((d) => {
-                  const colorMap: Record<Difficulty, string> = {
-                    easy: '#76ff03', normal: '#00e5ff', hard: '#ff9100', expert: '#ff4081',
-                  };
-                  return (
-                    <button
-                      key={d}
-                      onClick={() => { changeDifficulty(d); setShowMenu(false); }}
-                      className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${
-                        difficulty === d ? 'scale-105' : 'opacity-50 hover:opacity-75'
-                      }`}
-                      style={{
-                        borderColor: colorMap[d], borderWidth: 2, borderStyle: 'solid',
-                        color: difficulty === d ? colorMap[d] : '#999',
-                        background: difficulty === d ? `${colorMap[d]}18` : 'transparent',
-                      }}
-                    >
-                      {d.toUpperCase()}
-                      <span className="ml-1 opacity-75">(×{DIFFICULTY_MULTIPLIER[d]})</span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* 音声入力 */}
-            <button
-              onClick={async () => {
-                if (voiceActivation) {
-                  if (voiceActivation.isListening) {
-                    try {
-                      await voiceActivation.stopListening();
-                      setDebugMsg('🔇 音声検知を停止しました');
-                    } catch (err) {
-                      console.error('音声検知停止エラー:', err);
-                      setDebugMsg('⚠️ 音声検知停止エラー');
-                    }
-                  } else {
-                    try {
-                      await voiceActivation.startListening();
-                      setDebugMsg('🎤 音声検知を開始しました');
-                    } catch (err) {
-                      console.error('音声検知開始エラー:', err);
-                      setDebugMsg('⚠️ マイクアクセスが拒否または利用できません');
-                      setVoiceActivation(null);
-                    }
-                  }
-                } else {
-                  setDebugMsg('⚠️ 音声検知は利用できません（マイクアクセスが必要）');
-                }
-                setShowMenu(false);
-              }}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-              style={{
-                color: voiceActivation?.isListening ? '#76ff03'
-                  : voiceActivation?.isMicAccessible === false ? '#ff4444'
-                  : '#00e5ff',
-              }}
-            >
-              {voiceActivation?.isListening ? '🎤' : voiceActivation?.isMicAccessible === false ? '🔇' : '🔊'}
-              {' '}音声入力{voiceActivation?.isListening ? '（ON）' : '（OFF）'}
-            </button>
-
-            {/* アプリ情報 */}
-            <button
-              onClick={() => { router.push('/app-info'); setShowMenu(false); }}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-              style={{ color: '#00e5ff' }}
-            >
-              ℹ️ アプリ情報
-            </button>
-
-            {/* ヘルプ */}
-            <button
-              onClick={() => { setShowHelp(true); setShowMenu(false); }}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-bold transition-colors hover:bg-white/5"
-              style={{ color: '#00e5ff' }}
-            >
-              ❓ ヘルプ
-            </button>
-          </div>
-        </>
-      )}
-
-      {/* パターン名とページネーション - プレイ中は簡素化 */}
+            {/* パターン名とページネーション - プレイ中は簡素化 */}
       {!isActive && (
         <div className="flex items-center gap-2 text-sm">
           <button

--- a/src/components/MagicCircleCanvas.tsx
+++ b/src/components/MagicCircleCanvas.tsx
@@ -144,11 +144,19 @@ export default function MagicCircleCanvas({
               <div className="px-3 py-2">
                 <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
                 <div className="flex flex-wrap gap-1">
+                  {/* シングル（現在のモード・選択済み） */}
+                  <button
+                    className="rounded-md px-2 py-1 text-xs font-bold transition-all scale-105"
+                    style={{ borderColor: '#00e5ff', borderWidth: 2, borderStyle: 'solid', color: '#00e5ff', background: '#00e5ff18' }}
+                    disabled
+                  >
+                    シングル
+                  </button>
                   {unlocks?.multiMode && (
                     <button
                       onClick={() => { onSwitchMode?.('multi', difficulty); setShowMenu(false); }}
                       className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
-                      style={{ borderColor: '#7c4dff', borderWidth: 2, borderStyle: 'solid', color: '#7c4dff', background: 'transparent' }}
+                      style={{ borderColor: '#7c4dff', borderWidth: 2, borderStyle: 'solid', color: '#999', background: 'transparent' }}
                     >
                       ⚡ マルチ
                     </button>
@@ -157,7 +165,7 @@ export default function MagicCircleCanvas({
                     <button
                       onClick={() => { onSwitchMode?.('combo', difficulty); setShowMenu(false); }}
                       className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
-                      style={{ borderColor: '#ffd700', borderWidth: 2, borderStyle: 'solid', color: '#ffd700', background: 'transparent' }}
+                      style={{ borderColor: '#ffd700', borderWidth: 2, borderStyle: 'solid', color: '#999', background: 'transparent' }}
                     >
                       🔥 コンボ
                     </button>

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -43,10 +43,12 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
   const comboCountRef = useRef(0);
   const maxComboRef = useRef(0);
   const gameEndedRef = useRef(false);
+  const showHistoryRef = useRef(false);
 
   useEffect(() => { globalTimeLeftRef.current = globalTimeLeft; }, [globalTimeLeft]);
   useEffect(() => { scoresRef.current = scores; }, [scores]);
   useEffect(() => { circlesClearedRef.current = circlesCleared; }, [circlesCleared]);
+  useEffect(() => { showHistoryRef.current = showHistory; }, [showHistory]);
 
   const handleCircleScore = useCallback((result: ScoringResult) => {
     let storedResult = result;
@@ -119,17 +121,18 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
     return () => clearTimeout(timer);
   }, [timeLeft, isActive, showResult, isGameRunning, autoAdvancing, userPath.length, handleEvaluate, handleNext, isCombo]);
 
-  // グローバルタイマー（履歴パネル表示中は停止）
+  // グローバルタイマー（履歴パネル表示中はスキップ・インターバルはリセットしない）
   useEffect(() => {
-    if (!isGameRunning || showHistory) return;
+    if (!isGameRunning) return;
     const interval = setInterval(() => {
+      if (showHistoryRef.current) return;
       setGlobalTimeLeft(prev => {
         if (prev <= 1) { setIsGameRunning(false); return 0; }
         return prev - 1;
       });
     }, 1000);
     return () => clearInterval(interval);
-  }, [isGameRunning, showHistory]);
+  }, [isGameRunning]);
 
   // タイマー 0 → ゲーム終了
   useEffect(() => {
@@ -168,10 +171,10 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
   const handleSwitchModeFromMenu = useCallback((newMode: 'single' | 'multi' | 'combo', diff: Difficulty) => {
     if (newMode === 'single') {
       handleEndSession();
-    } else {
+    } else if (newMode !== mode) {
       onSwitchMode?.(newMode, diff);
     }
-  }, [handleEndSession, onSwitchMode]);
+  }, [handleEndSession, mode, onSwitchMode]);
 
   if (gameResult) {
     return <MultiModeResult result={gameResult} onExit={onExit} />;

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -199,9 +199,9 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
                 <button
                   onClick={() => { onExit(); setShowMenu(false); }}
                   className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
-                  style={{ borderColor: '#00e5ff', borderWidth: 2, borderStyle: 'solid', color: '#00e5ff', background: 'transparent' }}
+                  style={{ borderColor: '#00e5ff', borderWidth: 2, borderStyle: 'solid', color: '#999', background: 'transparent' }}
                 >
-                  ⚔️ シングル
+                  シングル
                 </button>
                 {/* マルチ */}
                 {(unlocks?.multiMode ?? true) && (

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -12,12 +12,14 @@ import {
   getComboMultiplier,
 } from '@/lib/multiModeConstants';
 import MultiModeResult from './MultiModeResult';
+import GameMenu from './GameMenu';
+import HistoryPanel from './HistoryPanel';
 
 interface Props {
   mode: 'multi' | 'combo';
   difficulty: Difficulty;
   onExit: () => void;
-  unlocks?: { multiMode?: boolean; comboMode?: boolean };
+  unlocks?: { history?: boolean; multiMode?: boolean; grimoire?: boolean; comboMode?: boolean };
   onSwitchMode?: (mode: 'multi' | 'combo', difficulty: Difficulty) => void;
 }
 
@@ -32,7 +34,7 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
   const [autoAdvancing, setAutoAdvancing] = useState(false);
   const [comboCount, setComboCount] = useState(0);
   const [comboBreak, setComboBreak] = useState(false);
-  const [showMenu, setShowMenu] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const [gameResult, setGameResult] = useState<import('./MultiModeResult').MultiModeGameResult | null>(null);
 
   const globalTimeLeftRef = useRef(globalTimeLeft);
@@ -163,6 +165,14 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
     buildAndSetResult(globalTimeLeftRef.current);
   }, [buildAndSetResult]);
 
+  const handleSwitchModeFromMenu = useCallback((newMode: 'single' | 'multi' | 'combo', diff: Difficulty) => {
+    if (newMode === 'single') {
+      onExit();
+    } else {
+      onSwitchMode?.(newMode, diff);
+    }
+  }, [onExit, onSwitchMode]);
+
   if (gameResult) {
     return <MultiModeResult result={gameResult} onExit={onExit} />;
   }
@@ -173,69 +183,22 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
 
   return (
     <div className="flex flex-col items-center gap-4 p-4">
-      {/* ☰ メニューボタン */}
-      <button
-        onClick={() => setShowMenu(v => !v)}
-        className="absolute right-4 top-4 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 text-xl font-bold"
-        style={{ borderColor: 'rgba(0,229,255,0.5)', color: '#00e5ff', background: 'rgba(10,10,20,0.8)' }}
-        aria-label="メニュー"
-      >
-        ☰
-      </button>
+      {/* 作成履歴パネル */}
+      <HistoryPanel
+        isOpen={showHistory}
+        onClose={() => setShowHistory(false)}
+        onSelect={() => setShowHistory(false)}
+      />
 
-      {/* メニューパネル */}
-      {showMenu && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
-          <div
-            className="absolute right-4 top-14 z-50 flex min-w-[240px] flex-col gap-1 rounded-xl border p-2"
-            style={{ background: 'rgba(13,13,26,0.97)', borderColor: 'rgba(0,229,255,0.3)' }}
-          >
-            {/* モード変更 */}
-            <div className="px-3 py-2">
-              <div className="mb-2 text-xs font-bold text-gray-500">🎮 モード変更</div>
-              <div className="flex flex-wrap gap-1">
-                {/* シングルモードに戻る */}
-                <button
-                  onClick={() => { onExit(); setShowMenu(false); }}
-                  className="rounded-md px-2 py-1 text-xs font-bold transition-all opacity-60 hover:opacity-100"
-                  style={{ borderColor: '#00e5ff', borderWidth: 2, borderStyle: 'solid', color: '#999', background: 'transparent' }}
-                >
-                  シングル
-                </button>
-                {/* マルチ */}
-                {(unlocks?.multiMode ?? true) && (
-                  <button
-                    onClick={() => { if (mode !== 'multi') { onSwitchMode?.('multi', difficulty); } setShowMenu(false); }}
-                    className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${mode === 'multi' ? 'scale-105' : 'opacity-60 hover:opacity-100'}`}
-                    style={{
-                      borderColor: '#7c4dff', borderWidth: 2, borderStyle: 'solid',
-                      color: mode === 'multi' ? '#7c4dff' : '#999',
-                      background: mode === 'multi' ? '#7c4dff18' : 'transparent',
-                    }}
-                  >
-                    ⚡ マルチ
-                  </button>
-                )}
-                {/* コンボ */}
-                {unlocks?.comboMode && (
-                  <button
-                    onClick={() => { if (mode !== 'combo') { onSwitchMode?.('combo', difficulty); } setShowMenu(false); }}
-                    className={`rounded-md px-2 py-1 text-xs font-bold transition-all ${mode === 'combo' ? 'scale-105' : 'opacity-60 hover:opacity-100'}`}
-                    style={{
-                      borderColor: '#ffd700', borderWidth: 2, borderStyle: 'solid',
-                      color: mode === 'combo' ? '#ffd700' : '#999',
-                      background: mode === 'combo' ? '#ffd70018' : 'transparent',
-                    }}
-                  >
-                    🔥 コンボ
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        </>
-      )}
+      {/* 共通メニュー */}
+      <GameMenu
+        currentMode={mode}
+        difficulty={difficulty}
+        unlocks={unlocks}
+        onSwitchMode={handleSwitchModeFromMenu}
+        onChangeDifficulty={changeDifficulty}
+        onShowHistory={() => setShowHistory(true)}
+      />
 
       {/* グローバルタイマー HUD */}
       <div className="w-full max-w-[350px]">

--- a/src/components/MultiModeGame.tsx
+++ b/src/components/MultiModeGame.tsx
@@ -119,9 +119,9 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
     return () => clearTimeout(timer);
   }, [timeLeft, isActive, showResult, isGameRunning, autoAdvancing, userPath.length, handleEvaluate, handleNext, isCombo]);
 
-  // グローバルタイマー
+  // グローバルタイマー（履歴パネル表示中は停止）
   useEffect(() => {
-    if (!isGameRunning) return;
+    if (!isGameRunning || showHistory) return;
     const interval = setInterval(() => {
       setGlobalTimeLeft(prev => {
         if (prev <= 1) { setIsGameRunning(false); return 0; }
@@ -129,7 +129,7 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
       });
     }, 1000);
     return () => clearInterval(interval);
-  }, [isGameRunning]);
+  }, [isGameRunning, showHistory]);
 
   // タイマー 0 → ゲーム終了
   useEffect(() => {
@@ -167,11 +167,11 @@ export default function MultiModeGame({ mode, difficulty, onExit, unlocks, onSwi
 
   const handleSwitchModeFromMenu = useCallback((newMode: 'single' | 'multi' | 'combo', diff: Difficulty) => {
     if (newMode === 'single') {
-      onExit();
+      handleEndSession();
     } else {
       onSwitchMode?.(newMode, diff);
     }
-  }, [onExit, onSwitchMode]);
+  }, [handleEndSession, onSwitchMode]);
 
   if (gameResult) {
     return <MultiModeResult result={gameResult} onExit={onExit} />;


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

- シングル/マルチ/コンボモードで共通の `GameMenu` コンポーネントを作成し、全モードで同一のメニュー構成を提供
- コードレビューで発見されたバグを2回修正

## 変更内容

### 新規: `GameMenu.tsx`
- モード変更・魔導書・作成履歴・レベル変更・音声入力・アプリ情報・ヘルプを統合した共通メニュー
- `currentMode` に応じてシングル/マルチ/コンボボタンの選択状態を正しくハイライト表示
- マルチ/コンボモード中は `unlocks` が未設定でもモード変更セクションを表示

### `MagicCircleCanvas.tsx`
- 個別のメニュー実装を削除し `GameMenu` を使用

### `MultiModeGame.tsx`
- 個別のメニュー実装を削除し `GameMenu` を使用
- 作成履歴パネル (`HistoryPanel`) を追加

### バグ修正 (コードレビュー対応)
1. メニューから「シングル」を選ぶと結果画面をスキップしていた → `handleEndSession()` 経由で結果表示
2. 同一モードへの切替でゲーム状態が失われるガード漏れ → `newMode !== mode` チェック追加
3. 作成履歴パネル表示中もタイマーが減り続ける問題 → ref でスキップしインターバルはリセットしない
4. `DIFFICULTY_LABELS` 定数の重複・命名衝突 → `DIFFICULTY_MULTIPLIER` を直接インポート
5. `page.tsx` の冗長な unlocks スプレッドを簡略化

## テスト計画
- [ ] シングル/マルチ/コンボ全モードで ☰ メニューが同じ構成で表示される
- [ ] 現在のモードがハイライト表示される（シングルはシングル、マルチはマルチ）
- [ ] マルチモード中に「シングル」を選ぶとスコア結果が表示される
- [ ] 作成履歴を開いている間タイマーが止まる

https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012itpjU5uMF9BbiAVorupau)_